### PR TITLE
Finish Feature/feature low level allocators:

### DIFF
--- a/doc/options.md
+++ b/doc/options.md
@@ -4,7 +4,7 @@
 
 There are the following variables available to configure it:
 
-* `FOONATHAN_MEMORY_DEFAULT_ALLOCATOR`: The default allocator used by the higher level allocator classes. One of the low level stateless allocators (see \ref foonathan::memory::default_allocator). Default is `heap_allocator`.
+* `FOONATHAN_MEMORY_DEFAULT_ALLOCATOR`: The default allocator used by the higher level allocator classes. One of the low level allocators (see \ref foonathan::memory::default_allocator). Default is `heap_allocator`.
 * `FOONATHAN_MEMORY_THREAD_SAFE_REFERENCE`: Whether or not the `allocator_reference` is thread safe by default. Default is `ON`.
 * `FOONATHAN_MEMORY_DEBUG_*`: specifies debugging options such as pointer check in `deallocate()` or filling newly allocated memory with values. All of them are enabled in `Debug` builds by default, the faster ones in `RelWithDebInfo` and none in `Release`. See [debugging](md_doc_debug_error.html#debugging) for a detailed description.
 

--- a/doc/options.md
+++ b/doc/options.md
@@ -4,7 +4,7 @@
 
 There are the following variables available to configure it:
 
-* `FOONATHAN_MEMORY_DEFAULT_ALLOCATOR`: The default allocator used by the higher level allocator classes. Either `heap_allocator` or `new_allocator`. Default is `heap_allocator`.
+* `FOONATHAN_MEMORY_DEFAULT_ALLOCATOR`: The default allocator used by the higher level allocator classes. One of the low level stateless allocators (see \ref foonathan::memory::default_allocator). Default is `heap_allocator`.
 * `FOONATHAN_MEMORY_THREAD_SAFE_REFERENCE`: Whether or not the `allocator_reference` is thread safe by default. Default is `ON`.
 * `FOONATHAN_MEMORY_DEBUG_*`: specifies debugging options such as pointer check in `deallocate()` or filling newly allocated memory with values. All of them are enabled in `Debug` builds by default, the faster ones in `RelWithDebInfo` and none in `Release`. See [debugging](md_doc_debug_error.html#debugging) for a detailed description.
 

--- a/include/foonathan/memory/config.hpp
+++ b/include/foonathan/memory/config.hpp
@@ -105,6 +105,7 @@
     #define FOONATHAN_MEMORY_DEBUG_FILL 1
 
     /// The size of the fence memory, it has no effect if \ref FOONATHAN_MEMORY_DEBUG_FILL is \c false.
+    /// \note For most allocators, the actual value doesn't matter and they use appropriate defaults to ensure alignment etc.
     /// \ingroup memory
     #define FOONATHAN_MEMORY_DEBUG_FENCE 1
 

--- a/include/foonathan/memory/default_allocator.hpp
+++ b/include/foonathan/memory/default_allocator.hpp
@@ -11,6 +11,7 @@
 #include "config.hpp"
 #include "heap_allocator.hpp"
 #include "new_allocator.hpp"
+#include "static_allocator.hpp"
 
 #if FOONATHAN_HOSTED_IMPLEMENTATION
     #include "malloc_allocator.hpp"
@@ -23,7 +24,7 @@ namespace foonathan { namespace memory
     /// They get an implementation allocator that will be used for their internal allocation,
     /// this type is the default value.
     /// \requiredbe Its type can be changed via the CMake option \c FOONATHAN_MEMORY_DEFAULT_ALLCOATOR,
-    /// but it must be one of the following: \ref heap_allocator, \ref new_allocator, \ref malloc_allocator.
+    /// but it must be one of the following: \ref heap_allocator, \ref new_allocator, \ref malloc_allocator, \ref static_allocator.
     /// \defaultbe The default is \ref heap_allocator.
     /// \ingroup memory
     using default_allocator = FOONATHAN_IMPL_DEFINED(FOONATHAN_MEMORY_IMPL_DEFAULT_ALLOCATOR);

--- a/include/foonathan/memory/default_allocator.hpp
+++ b/include/foonathan/memory/default_allocator.hpp
@@ -12,6 +12,10 @@
 #include "heap_allocator.hpp"
 #include "new_allocator.hpp"
 
+#if FOONATHAN_HOSTED_IMPLEMENTATION
+    #include "malloc_allocator.hpp"
+#endif
+
 namespace foonathan { namespace memory
 {
     /// The default \concept{concept_rawallocator,RawAllocator} that will be used as implementation allocator in memory arenas.
@@ -19,7 +23,7 @@ namespace foonathan { namespace memory
     /// They get an implementation allocator that will be used for their internal allocation,
     /// this type is the default value.
     /// \requiredbe Its type can be changed via the CMake option \c FOONATHAN_MEMORY_DEFAULT_ALLCOATOR,
-    /// but it must be one of the following: \ref heap_allocator, \ref new_allocator.
+    /// but it must be one of the following: \ref heap_allocator, \ref new_allocator, \ref malloc_allocator.
     /// \defaultbe The default is \ref heap_allocator.
     /// \ingroup memory
     using default_allocator = FOONATHAN_IMPL_DEFINED(FOONATHAN_MEMORY_IMPL_DEFAULT_ALLOCATOR);

--- a/include/foonathan/memory/default_allocator.hpp
+++ b/include/foonathan/memory/default_allocator.hpp
@@ -12,6 +12,7 @@
 #include "heap_allocator.hpp"
 #include "new_allocator.hpp"
 #include "static_allocator.hpp"
+#include "virtual_memory.hpp"
 
 #if FOONATHAN_HOSTED_IMPLEMENTATION
     #include "malloc_allocator.hpp"
@@ -24,7 +25,7 @@ namespace foonathan { namespace memory
     /// They get an implementation allocator that will be used for their internal allocation,
     /// this type is the default value.
     /// \requiredbe Its type can be changed via the CMake option \c FOONATHAN_MEMORY_DEFAULT_ALLCOATOR,
-    /// but it must be one of the following: \ref heap_allocator, \ref new_allocator, \ref malloc_allocator, \ref static_allocator.
+    /// but it must be one of the following: \ref heap_allocator, \ref new_allocator, \ref malloc_allocator, \ref static_allocator, \ref virtual_memory_allocator.
     /// \defaultbe The default is \ref heap_allocator.
     /// \ingroup memory
     using default_allocator = FOONATHAN_IMPL_DEFINED(FOONATHAN_MEMORY_IMPL_DEFAULT_ALLOCATOR);

--- a/include/foonathan/memory/error.hpp
+++ b/include/foonathan/memory/error.hpp
@@ -112,7 +112,7 @@ namespace foonathan { namespace memory
         std::size_t amount_;
     };
 
-    /// The exception class thrown if a size or alignemnt parameter in an allocation function exceeds the supported maximum.
+    /// The exception class thrown if a size or alignment parameter in an allocation function exceeds the supported maximum.
     /// It is derived from \c std::bad_alloc.
     /// This is either a node size, an array size or an alignment value.
     /// Throwing can be prohibited by the handler function.

--- a/include/foonathan/memory/heap_allocator.hpp
+++ b/include/foonathan/memory/heap_allocator.hpp
@@ -32,7 +32,7 @@ namespace foonathan { namespace memory
     /// The size parameter will not be zero.
     /// It shall return a \c nullptr if no memory is available.
     /// It must be thread safe.
-    /// \defaultbe On a hosted implementation this function simply calls \c std::malloc.
+    /// \defaultbe On a hosted implementation this function uses OS specific facilities, \c std::malloc is used as fallback.
     void* heap_alloc(std::size_t size) FOONATHAN_NOEXCEPT;
 
     /// Deallocates heap memory.
@@ -42,7 +42,7 @@ namespace foonathan { namespace memory
     /// It shall free the memory.
     /// The pointer will not be zero.
     /// It must be thread safe.
-    /// \defaultbe On a freestanding implementation this function simply calls \c std::free.
+    /// \defaultbe On a hosted implementation this function uses OS specific facilities, \c std::free is used as fallback.
     void heap_dealloc(void *ptr, std::size_t size) FOONATHAN_NOEXCEPT;
 
     /// A stateless \concept{concept_rawallocator,RawAllocator} that allocates memory from the heap.
@@ -73,7 +73,7 @@ namespace foonathan { namespace memory
         /// It uses \ref heap_dealloc.
         void deallocate_node(void *ptr, std::size_t size, std::size_t alignment) FOONATHAN_NOEXCEPT;
 
-        /// \returns The maximum node size by forwaring to \c std::allocator<char>::max_size()
+        /// \returns The maximum node size by forwarding to \c std::allocator<char>::max_size(), an OS specific facility
         /// or the maximum value on a freestanding implementation.
         std::size_t max_node_size() const FOONATHAN_NOEXCEPT;
     };

--- a/include/foonathan/memory/malloc_allocator.hpp
+++ b/include/foonathan/memory/malloc_allocator.hpp
@@ -1,0 +1,63 @@
+// Copyright (C) 2015 Jonathan Müller <jonathanmueller.dev@gmail.com>
+// This file is subject to the license terms in the LICENSE file
+// found in the top-level directory of this distribution.
+
+#ifndef FOONATHAN_MEMORY_MALLOC_ALLOCATOR_HPP_INCLUDED
+#define FOONATHAN_MEMORY_MALLOC_ALLOCATOR_HPP_INCLUDED
+
+/// \file
+/// Class \ref foonathan::memory::malloc_allocator.
+/// \note Only available on a hosted implementation.
+
+#include <type_traits>
+
+#include "config.hpp"
+#if !FOONATHAN_HOSTED_IMPLEMENTATION
+    #error "This header is only available for a hosted implementation."
+#endif
+
+namespace foonathan { namespace memory
+{
+#if FOONATHAN_MEMORY_DEBUG_LEAK_CHECK
+    namespace detail
+    {
+        static struct malloc_allocator_leak_checker_initializer_t
+        {
+            malloc_allocator_leak_checker_initializer_t() FOONATHAN_NOEXCEPT;
+            ~malloc_allocator_leak_checker_initializer_t() FOONATHAN_NOEXCEPT;
+        } malloc_allocator_leak_checker_initializer;
+    } // namespace detail
+#endif
+
+    /// A stateless \concept{concept_rawallocator,RawAllocator} that allocates memory using <tt>std::malloc()</tt>.
+    /// \ingroup memory
+    class malloc_allocator
+    {
+    public:
+        using is_stateful = std::false_type;
+
+        malloc_allocator() FOONATHAN_NOEXCEPT = default;
+        malloc_allocator(malloc_allocator&&) FOONATHAN_NOEXCEPT {}
+        ~malloc_allocator() FOONATHAN_NOEXCEPT = default;
+
+        malloc_allocator& operator=(malloc_allocator &&) FOONATHAN_NOEXCEPT
+        {
+            return *this;
+        }
+
+        /// \effects A \concept{concept_rawallocator,RawAllocator} allocation function.
+        /// It uses the <tt>std::malloc()</tt> for the allocation.
+        /// \returns A pointer to a \concept{concept_node,node}, it will never be \c nullptr.
+        /// \throws An exception of type \ref out_of_memory or whatever is thrown by its handler if the allocation fails.
+        void* allocate_node(std::size_t size, std::size_t alignment);
+
+        /// \effects A \concept{concept_rawallocator,RawAllocator} deallocation function.
+        /// It uses <tt>std::free()</tt>.
+        void deallocate_node(void *node, std::size_t size, std::size_t alignment) FOONATHAN_NOEXCEPT;
+
+        /// \returns The maximum node size by forwarding to \c std::allocator<char>::max_size().
+        std::size_t max_node_size() const FOONATHAN_NOEXCEPT;
+    };
+}} // namespace foonathan::memory
+
+#endif //FOONATHAN_MEMORY_MALLOC_ALLOCATOR_HPP_INCLUDED

--- a/include/foonathan/memory/malloc_allocator.hpp
+++ b/include/foonathan/memory/malloc_allocator.hpp
@@ -46,7 +46,7 @@ namespace foonathan { namespace memory
         }
 
         /// \effects A \concept{concept_rawallocator,RawAllocator} allocation function.
-        /// It uses the <tt>std::malloc()</tt> for the allocation.
+        /// It uses <tt>std::malloc()</tt> for the allocation.
         /// \returns A pointer to a \concept{concept_node,node}, it will never be \c nullptr.
         /// \throws An exception of type \ref out_of_memory or whatever is thrown by its handler if the allocation fails.
         void* allocate_node(std::size_t size, std::size_t alignment);

--- a/include/foonathan/memory/new_allocator.hpp
+++ b/include/foonathan/memory/new_allocator.hpp
@@ -50,10 +50,10 @@ namespace foonathan { namespace memory
         void* allocate_node(std::size_t size, std::size_t alignment);
 
         /// \effects A \concept{concept_rawallocator,RawAllocator} deallocation function.
-        /// It uses <tt>operator delete</tt>
+        /// It uses <tt>operator delete</tt>.
         void deallocate_node(void *node, std::size_t size, std::size_t alignment) FOONATHAN_NOEXCEPT;
 
-        /// \returns The maximum node size by forwaring to \c std::allocator<char>::max_size()
+        /// \returns The maximum node size by forwarding to \c std::allocator<char>::max_size()
         /// or the maximum value on a freestanding implementation.
         std::size_t max_node_size() const FOONATHAN_NOEXCEPT;
     };

--- a/include/foonathan/memory/static_allocator.hpp
+++ b/include/foonathan/memory/static_allocator.hpp
@@ -1,0 +1,90 @@
+// Copyright (C) 2015 Jonathan Müller <jonathanmueller.dev@gmail.com>
+// This file is subject to the license terms in the LICENSE file
+// found in the top-level directory of this distribution.
+
+#ifndef FOONATHAN_MEMORY_STATIC_ALLOCATOR_HPP_INCLUDED
+#define FOONATHAN_MEMORY_STATIC_ALLOCATOR_HPP_INCLUDED
+
+/// \file
+/// Class \ref foonathan::memory::static_allocator and \ref foonathan::memory::static_allocator_storage.
+
+#include <type_traits>
+
+#include "detail/align.hpp"
+#include "detail/memory_stack.hpp"
+#include "config.hpp"
+
+namespace foonathan { namespace memory
+{
+    /// Storage for a \ref static_allocator.
+    /// Its constructor will take a reference to it and use it for its allocation.
+    /// The storage type is simply a \c char array aligned for maximum alignment.
+    /// \note It is not allowed to access the memory of the storage.
+    /// \ingroup memory
+    template <std::size_t Size>
+    FOONATHAN_ALIAS_TEMPLATE(static_allocator_storage, typename std::aligned_storage<1, detail::max_alignment>::type[Size]);
+
+    /// A stateful \concept{concept_rawallocator,RawAllocator} that uses a fixed sized storage for the allocations.
+    /// It works on a \ref static_allocator_storage and uses its memory for all allocations.
+    /// Deallocations are not supported, memory cannot be marked as freed.<br>
+    /// Its main use is as implementation allocator in memory arenas.
+    /// Create a \ref static_allocator_storage of the block size of the arena onto the stack
+    /// and pass it to the arena.
+    /// This will create an arena of fixed size whose memory is created on the stack and which cannot grow.
+    /// It thus allows to have complex containers like \c std::unordered_map located on the program stack.
+    /// \note It is not allowed to share an \ref static_allocator_storage between multiple \ref static_allocators.
+    /// \ingroup memory
+    class static_allocator
+    {
+    public:
+        using is_stateful = std::true_type;
+
+        /// \effects Creates it by passing it a \ref static_allocator_storage by reference.
+        /// It will take the address of the storage and use its memory for the allocation.
+        /// \requires The storage object must live as long as the allocator object.
+        /// It must not be shared between multiple allocators,
+        /// i.e. the object must not have been passed to a constructor before.
+        template <std::size_t Size>
+        static_allocator(static_allocator_storage<Size> &storage) FOONATHAN_NOEXCEPT
+        : stack_(&storage, Size) {}
+
+        /// \effects A \concept{concept_rawallocator,RawAllocator} allocation function.
+        /// It uses the specified \ref static_allocator_storage.
+        /// \returns A pointer to a \concept{concept_node,node}, it will never be \c nullptr.
+        /// \throws An exception of type \ref out_of_memory or whatever is thrown by its handler if the storage is exhausted.
+        void* allocate_node(std::size_t size, std::size_t alignment)
+        {
+            auto mem = stack_.allocate(size, alignment);
+            if (!mem)
+                FOONATHAN_THROW(out_of_memory(info(), size));
+            return mem;
+        }
+
+        /// \effects A \concept{concept_rawallocator,RawAllocator} deallocation function.
+        /// It does nothing, deallocation is not supported by this allocator.
+        void deallocate_node(void *, std::size_t, std::size_t) FOONATHAN_NOEXCEPT {}
+
+        /// \returns The maximum node size which is the capacity remaining inside the \ref static_allocator_storage.
+        std::size_t max_node_size() const FOONATHAN_NOEXCEPT
+        {
+            return stack_.end() - stack_.top();
+        }
+
+        /// \returns The maximum possible value since there is no alignment restriction
+        /// (except indirectly through the size of the \ref static_allocator_storage).
+        std::size_t max_alignment() const FOONATHAN_NOEXCEPT
+        {
+            return std::size_t(-1);
+        }
+
+    private:
+        allocator_info info() const FOONATHAN_NOEXCEPT
+        {
+            return {FOONATHAN_MEMORY_LOG_PREFIX "::static_allocator", this};
+        }
+
+        detail::fixed_memory_stack stack_;
+    };
+}} // namespace foonathan::memory
+
+#endif //FOONATHAN_MEMORY_STATIC_ALLOCATOR_HPP_INCLUDED

--- a/include/foonathan/memory/static_allocator.hpp
+++ b/include/foonathan/memory/static_allocator.hpp
@@ -22,7 +22,10 @@ namespace foonathan { namespace memory
     /// \note It is not allowed to access the memory of the storage.
     /// \ingroup memory
     template <std::size_t Size>
-    FOONATHAN_ALIAS_TEMPLATE(static_allocator_storage, typename std::aligned_storage<1, detail::max_alignment>::type[Size]);
+    struct static_allocator_storage
+    {
+        typename std::aligned_storage<1, detail::max_alignment>::type storage[Size];
+    };
 
     /// A stateful \concept{concept_rawallocator,RawAllocator} that uses a fixed sized storage for the allocations.
     /// It works on a \ref static_allocator_storage and uses its memory for all allocations.

--- a/include/foonathan/memory/static_allocator.hpp
+++ b/include/foonathan/memory/static_allocator.hpp
@@ -24,8 +24,11 @@ namespace foonathan { namespace memory
     template <std::size_t Size>
     struct static_allocator_storage
     {
-        typename std::aligned_storage<1, detail::max_alignment>::type storage[Size];
+        typename std::aligned_storage<Size, detail::max_alignment>::type storage;
     };
+
+    static_assert(sizeof(static_allocator_storage<1024>) == 1024, "");
+    static_assert(FOONATHAN_ALIGNOF(static_allocator_storage<1024>) == detail::max_alignment, "");
 
     /// A stateful \concept{concept_rawallocator,RawAllocator} that uses a fixed sized storage for the allocations.
     /// It works on a \ref static_allocator_storage and uses its memory for all allocations.

--- a/include/foonathan/memory/virtual_memory.hpp
+++ b/include/foonathan/memory/virtual_memory.hpp
@@ -1,0 +1,50 @@
+// Copyright (C) 2015 Jonathan Müller <jonathanmueller.dev@gmail.com>
+// This file is subject to the license terms in the LICENSE file
+// found in the top-level directory of this distribution.
+
+#ifndef FOONATHAN_MEMORY_VIRTUAL_MEMORY_HPP_INCLUDED
+#define FOONATHAN_MEMORY_VIRTUAL_MEMORY_HPP_INCLUDED
+
+#include <cstddef>
+
+#include "config.hpp"
+
+namespace foonathan { namespace memory
+{
+    /// The page size of the virtual memory.
+    /// All virtual memory allocations must be multiple of this size.
+    /// It is usually 4KiB.
+    /// \ingroup memory
+    extern const std::size_t virtual_memory_page_size;
+
+    /// Reserves virtual memory.
+    /// \effects Reserves the given number of pages.
+    /// Each page is \ref virtual_memory_page_size big.
+    /// \returns The address of the first reserved page,
+    /// or \c nullptr in case of error.
+    /// \note The memory may not be used, it must first be commited.
+    /// \ingroup memory
+    void* virtual_memory_reserve(std::size_t no_pages) FOONATHAN_NOEXCEPT;
+
+    /// Releases reserved virtual memory.
+    /// \effects Returns previously reserved pages to the system.
+    /// \requires \c pages must come from a previous call to \ref virtual_memory_reserve with the same \c no_pages,
+    /// it must not be \c nullptr.
+    /// \ingroup memory
+    void virtual_memory_release(void *pages, std::size_t no_pages) FOONATHAN_NOEXCEPT;
+
+    /// Commits reserved virtual memory.
+    /// \effects Marks \c no_pages pages starting at the given address available for use.
+    /// \returns The beginning of the commited area, i.e. \c memory, or \c nullptr in case of error.
+    /// \ingroup memory
+    void* virtual_memory_commit(void *memory, std::size_t no_pages) FOONATHAN_NOEXCEPT;
+
+    /// Decommits commited virtual memory.
+    /// \effects Puts commited memory back in the reserved state.
+    /// \requires \c memory must come from a previous call to \ref virtual_memory_commit with the same \c no_pages
+    /// it must not be \c nullptr.
+    /// \ingroup memory
+    void virtual_memory_decommit(void *memory, std::size_t no_pages) FOONATHAN_NOEXCEPT;
+}} // namespace foonathan::memory
+
+#endif //FOONATHAN_MEMORY_VIRTUAL_MEMORY_HPP_INCLUDED

--- a/include/foonathan/memory/virtual_memory.hpp
+++ b/include/foonathan/memory/virtual_memory.hpp
@@ -6,11 +6,23 @@
 #define FOONATHAN_MEMORY_VIRTUAL_MEMORY_HPP_INCLUDED
 
 #include <cstddef>
+#include <type_traits>
 
 #include "config.hpp"
 
 namespace foonathan { namespace memory
 {
+#if FOONATHAN_MEMORY_DEBUG_LEAK_CHECK
+    namespace detail
+    {
+        static struct virtual_memory_allocator_leak_checker_initializer_t
+        {
+            virtual_memory_allocator_leak_checker_initializer_t() FOONATHAN_NOEXCEPT;
+            ~virtual_memory_allocator_leak_checker_initializer_t() FOONATHAN_NOEXCEPT;
+        } virtual_memory_allocator_leak_checker_initializer;
+    } // namespace detail
+#endif
+
     /// The page size of the virtual memory.
     /// All virtual memory allocations must be multiple of this size.
     /// It is usually 4KiB.
@@ -28,23 +40,62 @@ namespace foonathan { namespace memory
 
     /// Releases reserved virtual memory.
     /// \effects Returns previously reserved pages to the system.
-    /// \requires \c pages must come from a previous call to \ref virtual_memory_reserve with the same \c no_pages,
+    /// \requires \c pages must come from a previous call to \ref virtual_memory_reserve with the same \c calc_no_pages,
     /// it must not be \c nullptr.
     /// \ingroup memory
     void virtual_memory_release(void *pages, std::size_t no_pages) FOONATHAN_NOEXCEPT;
 
     /// Commits reserved virtual memory.
-    /// \effects Marks \c no_pages pages starting at the given address available for use.
-    /// \returns The beginning of the commited area, i.e. \c memory, or \c nullptr in case of error.
+    /// \effects Marks \c calc_no_pages pages starting at the given address available for use.
+    /// \returns The beginning of the committed area, i.e. \c memory, or \c nullptr in case of error.
+    /// \requires The memory must be previously reserved.
     /// \ingroup memory
     void* virtual_memory_commit(void *memory, std::size_t no_pages) FOONATHAN_NOEXCEPT;
 
     /// Decommits commited virtual memory.
     /// \effects Puts commited memory back in the reserved state.
-    /// \requires \c memory must come from a previous call to \ref virtual_memory_commit with the same \c no_pages
+    /// \requires \c memory must come from a previous call to \ref virtual_memory_commit with the same \c calc_no_pages
     /// it must not be \c nullptr.
     /// \ingroup memory
     void virtual_memory_decommit(void *memory, std::size_t no_pages) FOONATHAN_NOEXCEPT;
+
+    /// A stateless \concept{concept_rawallocator,RawAllocator} that allocates memory using the virtual memory allocation functions.
+    /// It does not prereserve any memory and will always reserve and commit combined.
+    /// \ingroup memory
+    class virtual_memory_allocator
+    {
+    public:
+        using is_stateful = std::false_type;
+
+        virtual_memory_allocator() FOONATHAN_NOEXCEPT = default;
+        virtual_memory_allocator(virtual_memory_allocator&&) FOONATHAN_NOEXCEPT {}
+        ~virtual_memory_allocator() FOONATHAN_NOEXCEPT = default;
+
+        virtual_memory_allocator& operator=(virtual_memory_allocator &&) FOONATHAN_NOEXCEPT
+        {
+            return *this;
+        }
+
+        /// \effects A \concept{concept_rawallocator,RawAllocator} allocation function.
+        /// It uses \ref virtual_memory_reserve followed by \ref virtual_memory_commit for the allocation.
+        /// The number of pages allocated will be the minimum to hold \c size continuous bytes,
+        /// i.e. \c size will be rounded up to the next multiple.
+        /// If debug fences are activated, one additional page before and after the memory will be allocated.
+        /// \returns A pointer to a \concept{concept_node,node}, it will never be \c nullptr.
+        /// It will always be aligned on a fence boundary, regardless of the alignment parameter.
+        /// \throws An exception of type \ref out_of_memory or whatever is thrown by its handler if the allocation fails.
+        void* allocate_node(std::size_t size, std::size_t alignment);
+
+        /// \effects A \concept{concept_rawallocator,RawAllocator} deallocation function.
+        /// It calls \ref virtual_memory_decommit followed by \ref virtual_memory_release for the deallocation.
+        void deallocate_node(void *node, std::size_t size, std::size_t alignment) FOONATHAN_NOEXCEPT;
+
+        /// \returns The maximum node size by returning the maximum value.
+        std::size_t max_node_size() const FOONATHAN_NOEXCEPT;
+
+        /// \returns The maximum alignment which is the same as the \ref virtual_memory_page_size.
+        std::size_t max_alignment() const FOONATHAN_NOEXCEPT;
+    };
 }} // namespace foonathan::memory
 
 #endif //FOONATHAN_MEMORY_VIRTUAL_MEMORY_HPP_INCLUDED

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -30,6 +30,7 @@ set(header
         ${header_path}/memory_stack.hpp
         ${header_path}/new_allocator.hpp
         ${header_path}/smart_ptr.hpp
+        ${header_path}/static_allocator.hpp
         ${header_path}/std_allocator.hpp
         ${header_path}/temporary_allocator.hpp
         ${header_path}/threading.hpp

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -35,6 +35,7 @@ set(header
         ${header_path}/temporary_allocator.hpp
         ${header_path}/threading.hpp
         ${header_path}/tracking.hpp
+        ${header_path}/virtual_memory.hpp
         ${CMAKE_CURRENT_BINARY_DIR}/container_node_sizes.hpp)
 
 set(src
@@ -48,7 +49,8 @@ set(src
         heap_allocator.cpp
         malloc_allocator.cpp
         new_allocator.cpp
-        temporary_allocator.cpp)
+        temporary_allocator.cpp
+        virtual_memory.cpp)
 
 add_library(foonathan_memory ${header} ${src})
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -23,6 +23,7 @@ set(header
         ${header_path}/deleter.hpp
         ${header_path}/error.hpp
         ${header_path}/heap_allocator.hpp
+        ${header_path}/malloc_allocator.hpp
         ${header_path}/memory_pool.hpp
         ${header_path}/memory_pool_collection.hpp
         ${header_path}/memory_pool_type.hpp
@@ -44,6 +45,7 @@ set(src
         debugging.cpp
         error.cpp
         heap_allocator.cpp
+        malloc_allocator.cpp
         new_allocator.cpp
         temporary_allocator.cpp)
 

--- a/src/heap_allocator.cpp
+++ b/src/heap_allocator.cpp
@@ -49,7 +49,35 @@ using namespace foonathan::memory;
     }
 #endif
 
-#if FOONATHAN_HOSTED_IMPLEMENTATION
+#ifdef _WIN32
+    #include <malloc.h>
+    #include <windows.h>
+
+    namespace
+    {
+        HANDLE get_process_heap() FOONATHAN_NOEXCEPT
+        {
+            static auto heap = GetProcessHeap();
+            return heap;
+        }
+
+        std::size_t max_size() FOONATHAN_NOEXCEPT
+        {
+            return _HEAP_MAXREQ;
+        }
+    }
+
+    void* foonathan::memory::heap_alloc(std::size_t size) FOONATHAN_NOEXCEPT
+    {
+        return HeapAlloc(get_process_heap(), 0, size);
+    }
+
+    void foonathan::memory::heap_dealloc(void *ptr, std::size_t) FOONATHAN_NOEXCEPT
+    {
+        HeapFree(get_process_heap(), 0, ptr);
+    }
+
+#elif FOONATHAN_HOSTED_IMPLEMENTATION
     #include <cstdlib>
     #include <memory>
 
@@ -71,7 +99,7 @@ using namespace foonathan::memory;
         }
     }
 #else
-    // no implemenetation for heap_alloc/heap_dealloc
+    // no implementation for heap_alloc/heap_dealloc
 
     namespace
     {

--- a/src/heap_allocator.cpp
+++ b/src/heap_allocator.cpp
@@ -6,6 +6,7 @@
 
 #include <new>
 
+#include "detail/align.hpp"
 #include "debugging.hpp"
 #include "error.hpp"
 

--- a/src/malloc_allocator.cpp
+++ b/src/malloc_allocator.cpp
@@ -1,0 +1,77 @@
+// Copyright (C) 2015 Jonathan Müller <jonathanmueller.dev@gmail.com>
+// This file is subject to the license terms in the LICENSE file
+// found in the top-level directory of this distribution.
+
+#include "config.hpp"
+#if FOONATHAN_HOSTED_IMPLEMENTATION
+
+#include "malloc_allocator.hpp"
+
+#include <cstdlib>
+#include <memory>
+
+#include "debugging.hpp"
+#include "error.hpp"
+
+using namespace foonathan::memory;
+
+#if FOONATHAN_MEMORY_DEBUG_LEAK_CHECK
+    #include <atomic>
+
+    namespace
+    {
+        std::size_t init_counter = 0u, alloc_counter = 0u;
+
+        void on_alloc(std::size_t size) FOONATHAN_NOEXCEPT
+        {
+            alloc_counter += size;
+        }
+
+        void on_dealloc(std::size_t size) FOONATHAN_NOEXCEPT
+        {
+            alloc_counter -= size;
+        }
+    }
+
+    detail::malloc_allocator_leak_checker_initializer_t::malloc_allocator_leak_checker_initializer_t() FOONATHAN_NOEXCEPT
+    {
+        ++init_counter;
+    }
+
+    detail::malloc_allocator_leak_checker_initializer_t::~malloc_allocator_leak_checker_initializer_t() FOONATHAN_NOEXCEPT
+    {
+        if (--init_counter == 0u && alloc_counter != 0u)
+            get_leak_handler()({FOONATHAN_MEMORY_LOG_PREFIX "::malloc_allocator", nullptr}, alloc_counter);
+    }
+#else
+    namespace
+    {
+        void on_alloc(std::size_t) FOONATHAN_NOEXCEPT {}
+        void on_dealloc(std::size_t) FOONATHAN_NOEXCEPT {}
+    }
+#endif
+
+void* malloc_allocator::allocate_node(std::size_t size, std::size_t)
+{
+    auto memory = std::malloc(size + 2 * detail::debug_fence_size);
+    if (!memory)
+        FOONATHAN_THROW(out_of_memory({FOONATHAN_MEMORY_LOG_PREFIX "::malloc_allocator", this},
+                                      size + 2 * detail::debug_fence_size));
+    on_alloc(size);
+    return detail::debug_fill_new(memory, size);
+}
+
+void malloc_allocator::deallocate_node(void *ptr, std::size_t size, std::size_t) FOONATHAN_NOEXCEPT
+{
+    auto memory = detail::debug_fill_free(ptr, size);
+    std::free(memory);
+
+    on_dealloc(size);
+}
+
+std::size_t malloc_allocator::max_node_size() const FOONATHAN_NOEXCEPT
+{
+    return std::allocator<char>().max_size();
+}
+
+#endif

--- a/src/new_allocator.cpp
+++ b/src/new_allocator.cpp
@@ -8,6 +8,7 @@
     #include <memory>
 #endif
 
+#include "detail/align.hpp"
 #include "debugging.hpp"
 #include "error.hpp"
 
@@ -51,19 +52,21 @@ using namespace foonathan::memory;
 
 void* new_allocator::allocate_node(std::size_t size, std::size_t)
 {
+    auto actual_size = size + (detail::debug_fence_size ? 2 * detail::max_alignment : 0u);
+
     auto mem = detail::try_allocate([](std::size_t size)
                                     {
                                         return ::operator new(size,
                                                               std::nothrow);
-                                    }, size + 2 * detail::debug_fence_size,
+                                    }, actual_size,
                                     {FOONATHAN_MEMORY_LOG_PREFIX "::new_allocator", this});
     on_alloc(size);
-    return detail::debug_fill_new(mem, size);
+    return detail::debug_fill_new(mem, size, detail::max_alignment);
 }
 
 void new_allocator::deallocate_node(void* node, std::size_t size, std::size_t) FOONATHAN_NOEXCEPT
 {
-    auto memory = detail::debug_fill_free(node, size);
+    auto memory = detail::debug_fill_free(node, size, detail::max_alignment);
     ::operator delete(memory);
 
     on_dealloc(size);

--- a/src/virtual_memory.cpp
+++ b/src/virtual_memory.cpp
@@ -1,0 +1,112 @@
+// Copyright (C) 2015 Jonathan Müller <jonathanmueller.dev@gmail.com>
+// This file is subject to the license terms in the LICENSE file
+// found in the top-level directory of this distribution.
+
+#include "virtual_memory.hpp"
+
+#include "error.hpp"
+
+using namespace foonathan::memory;
+
+#if defined(_WIN32)
+    #include <windows.h>
+
+    namespace
+    {
+        std::size_t get_page_size() FOONATHAN_NOEXCEPT
+        {
+            static_assert(sizeof(std::size_t) >= sizeof(DWORD), "possible loss of data");
+
+            SYSTEM_INFO info;
+            GetSystemInfo(&info);
+            return std::size_t(info.dwPageSize);
+        }
+    }
+
+    const std::size_t foonathan::memory::virtual_memory_page_size = get_page_size();
+
+    void* foonathan::memory::virtual_memory_reserve(std::size_t no_pages) FOONATHAN_NOEXCEPT
+    {
+        auto pages = VirtualAlloc(nullptr, no_pages * virtual_memory_page_size, MEM_RESERVE, PAGE_READWRITE);
+        return pages;
+    }
+
+    void foonathan::memory::virtual_memory_release(void *pages, std::size_t) FOONATHAN_NOEXCEPT
+    {
+        auto result = VirtualFree(pages, 0u, MEM_RELEASE);
+        FOONATHAN_MEMORY_ASSERT_MSG(result, "cannot release pages");
+    }
+
+    void* foonathan::memory::virtual_memory_commit(void *memory, std::size_t no_pages) FOONATHAN_NOEXCEPT
+    {
+        auto region = VirtualAlloc(memory, no_pages * virtual_memory_page_size, MEM_COMMIT, PAGE_READWRITE);
+        if (!region)
+            return nullptr;
+        FOONATHAN_MEMORY_ASSERT(region == memory);
+        return region;
+    }
+
+    void foonathan::memory::virtual_memory_decommit(void *memory, std::size_t no_pages) FOONATHAN_NOEXCEPT
+    {
+        auto result = VirtualFree(memory, no_pages * virtual_memory_page_size, MEM_DECOMMIT);
+        FOONATHAN_MEMORY_ASSERT_MSG(result, "cannot decommit memory");
+    }
+#elif defined(__unix__) || defined(__APPLE__) // POSIX systems
+    #include <sys/mman.h>
+    #include <unistd.h>
+
+    #if defined(PAGESIZE)
+        const std::size_t foonathan::memory::virtual_memory_page_size = PAGESIZE;
+    #elif defined(PAGE_SIZE)
+        const std::size_t foonathan::memory::virtual_memory_page_size = PAGE_SIZE;
+    #else
+        const std::size_t foonathan::memory::virtual_memory_page_size = sysconf(_SC_PAGESIZE);
+    #endif
+
+    void* foonathan::memory::virtual_memory_reserve(std::size_t no_pages) FOONATHAN_NOEXCEPT
+    {
+        auto pages = mmap(nullptr, no_pages * virtual_memory_page_size, PROT_NONE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+        return pages == MAP_FAILED ? nullptr : pages;
+    }
+
+    void foonathan::memory::virtual_memory_release(void *pages, std::size_t no_pages) FOONATHAN_NOEXCEPT
+    {
+        auto result = munmap(pages, no_pages * virtual_memory_page_size);
+        FOONATHAN_MEMORY_ASSERT_MSG(result == 0, "cannot release pages");
+    }
+
+    void* foonathan::memory::virtual_memory_commit(void *memory, std::size_t no_pages) FOONATHAN_NOEXCEPT
+    {
+        auto size = no_pages * virtual_memory_page_size;
+        auto result = mprotect(memory, size, PROT_WRITE | PROT_READ);
+        if (result != 0u)
+            return nullptr;
+
+        // advise that the memory will be needed
+        #if defined(MADV_WILLNEED)
+            madvise(memory, size, MADV_WILLNEED);
+        #elif defined(POSIX_MADV_WILLNEED)
+            posix_madvise(memory, size, POSIX_MADV_WILLNEED);
+        #endif
+
+        return memory;
+    }
+
+    void foonathan::memory::virtual_memory_decommit(void *memory, std::size_t no_pages) FOONATHAN_NOEXCEPT
+    {
+         auto size = no_pages * virtual_memory_page_size;
+        // advise that the memory won't be needed anymore
+        #if defined(MADV_FREE)
+            madvise(memory, size, MADV_FREE);
+        #elif defined(MADV_DONTNEED)
+            madvise(memory, size, MADV_DONTNEED);
+        #elif defined(POSIX_MADV_DONTNEED)
+            posix_madvise(memory, size, POSIX_MADV_DONTNEED);
+        #endif
+
+        auto result = mprotect(memory, size, PROT_NONE);
+        FOONATHAN_MEMORY_ASSERT_MSG(result == 0, "cannot decommit memory");
+    }
+#else
+    #warning "virtual memory functions not available on your platform, define your own"
+#endif

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -38,6 +38,7 @@ set(tests
         detail/memory_stack.cpp
         aligned_allocator.cpp
         allocator_traits.cpp
+        default_allocator.cpp
         memory_pool.cpp
         memory_pool_collection.cpp
         memory_stack.cpp)

--- a/test/default_allocator.cpp
+++ b/test/default_allocator.cpp
@@ -70,5 +70,5 @@ TEST_CASE("static_allocator", "[default_allocator]")
 TEST_CASE("virtual_memory_allocator", "[default_allocator]")
 {
     virtual_memory_allocator alloc;
-    check_default_allocator(alloc);
+    check_default_allocator(alloc, virtual_memory_page_size);
 }

--- a/test/default_allocator.cpp
+++ b/test/default_allocator.cpp
@@ -1,0 +1,74 @@
+// Copyright (C) 2015 Jonathan Müller <jonathanmueller.dev@gmail.com>
+// This file is subject to the license terms in the LICENSE file
+// found in the top-level directory of this distribution.
+
+// tests all possible default allocator classes
+
+#include "default_allocator.hpp"
+
+#include <catch.hpp>
+
+#include "detail/align.hpp"
+
+using namespace foonathan::memory;
+
+// *very* simple test case to ensure proper alignment and might catch some segfaults
+template <class Allocator>
+void check_default_allocator(Allocator &alloc, std::size_t def_alignment = detail::max_alignment)
+{
+    auto ptr = alloc.allocate_node(1, 1);
+    REQUIRE(detail::is_aligned(ptr, def_alignment));
+
+    alloc.deallocate_node(ptr, 1, 1);
+
+    for (std::size_t i = 0u; i != 10u; ++i)
+    {
+        auto ptr = alloc.allocate_node(i, 1);
+        REQUIRE(detail::is_aligned(ptr, def_alignment));
+        alloc.deallocate_node(ptr, i, 1);
+    }
+
+    std::vector<void*> ptrs;
+    for (std::size_t i = 0u; i != 10u; ++i)
+    {
+        auto ptr = alloc.allocate_node(i, 1);
+        REQUIRE(detail::is_aligned(ptr, def_alignment));
+        ptrs.push_back(ptr);
+    }
+
+     for (std::size_t i = 0u; i != 10u; ++i)
+        alloc.deallocate_node(ptrs[i], i, 1);
+}
+
+TEST_CASE("heap_allocator", "[default_allocator]")
+{
+    heap_allocator alloc;
+    check_default_allocator(alloc);
+}
+
+TEST_CASE("new_allocator", "[default_allocator]")
+{
+    new_allocator alloc;
+    check_default_allocator(alloc);
+}
+
+TEST_CASE("malloc_allocator", "[default_allocator]")
+{
+    malloc_allocator alloc;
+    check_default_allocator(alloc);
+}
+
+TEST_CASE("static_allocator", "[default_allocator]")
+{
+    static_allocator_storage<1024> storage;
+    static_allocator alloc(storage);
+
+    // no need to test alignment issues here again, implemented by fixed_memory_stack
+    check_default_allocator(alloc, 1);
+}
+
+TEST_CASE("virtual_memory_allocator", "[default_allocator]")
+{
+    virtual_memory_allocator alloc;
+    check_default_allocator(alloc);
+}

--- a/test/detail/free_list.cpp
+++ b/test/detail/free_list.cpp
@@ -11,6 +11,7 @@
 #include <vector>
 
 #include "detail/align.hpp"
+#include "static_allocator.hpp"
 
 using namespace foonathan::memory;
 using namespace detail;
@@ -63,8 +64,8 @@ void check_list(FreeList &list, void *memory, std::size_t size)
 template <class FreeList>
 void check_move(FreeList &list)
 {
-    alignas(max_alignment) char memory[1024];
-    list.insert(memory, 1024);
+    static_allocator_storage<1024> memory;
+    list.insert(&memory, 1024);
 
     auto ptr = list.allocate();
     REQUIRE(ptr);
@@ -79,8 +80,8 @@ void check_move(FreeList &list)
 
     list2.deallocate(ptr);
 
-    alignas(max_alignment) char memory2[1024];
-    list.insert(memory2, 1024);
+    static_allocator_storage<1024> memory2;
+    list.insert(&memory2, 1024);
     REQUIRE(!list.empty());
     REQUIRE(list.capacity() <= 1024 / list.node_size());
 
@@ -109,20 +110,22 @@ TEST_CASE("free_memory_list", "[detail][pool]")
 
     SECTION("normal insert")
     {
-        alignas(max_alignment) char memory[1024];
-        check_list(list, memory, 1024);
+        static_allocator_storage<1024> memory;
+        check_list(list, &memory, 1024);
     }
     SECTION("uneven insert")
     {
-        alignas(max_alignment) char memory[1023]; // not dividable
-        check_list(list, memory, 1023);
+        static_allocator_storage<1023> memory; // not dividable
+        check_list(list, &memory, 1023);
     }
     SECTION("multiple insert")
     {
-        alignas(max_alignment) char a[1024], b[100], c[1337];
-        check_list(list, a, 1024);
-        check_list(list, b, 100);
-        check_list(list, c, 1337);
+        static_allocator_storage<1024> a;
+        static_allocator_storage<100> b;
+        static_allocator_storage<1337> c;
+        check_list(list, &a, 1024);
+        check_list(list, &b, 100);
+        check_list(list, &c, 1337);
     }
     check_move(list);
 }
@@ -167,24 +170,26 @@ TEST_CASE("ordered_free_memory_list", "[detail][pool]")
 
     SECTION("normal insert")
     {
-        alignas(max_alignment) char memory[1024];
-        check_list(list, memory, 1024);
+        static_allocator_storage<1024> memory;
+        check_list(list, &memory, 1024);
         use_list_array(list);
     }
     SECTION("uneven insert")
     {
-        alignas(max_alignment) char memory[1023]; // not dividable
-        check_list(list, memory, 1023);
+        static_allocator_storage<1023> memory; // not dividable
+        check_list(list, &memory, 1023);
         use_list_array(list);
     }
     SECTION("multiple insert")
     {
-        alignas(max_alignment) char a[1024], b[100], c[1337];
-        check_list(list, a, 1024);
+        static_allocator_storage<1024> a;
+        static_allocator_storage<100> b;
+        static_allocator_storage<1337> c;
+        check_list(list, &a, 1024);
         use_list_array(list);
-        check_list(list, b, 100);
+        check_list(list, &b, 100);
         use_list_array(list);
-        check_list(list, c, 1337);
+        check_list(list, &c, 1337);
         use_list_array(list);
     }
     check_move(list);
@@ -199,25 +204,27 @@ TEST_CASE("small_free_memory_list", "[detail][pool]")
 
     SECTION("normal insert")
     {
-        alignas(max_alignment) char memory[1024];
-        check_list(list, memory, 1024);
+        static_allocator_storage<1024> memory;
+        check_list(list, &memory, 1024);
     }
     SECTION("uneven insert")
     {
-        alignas(max_alignment) char memory[1023]; // not dividable
-        check_list(list, memory, 1023);
+        static_allocator_storage<1023> memory; // not dividable
+        check_list(list, &memory, 1023);
     }
     SECTION("big insert")
     {
-        alignas(max_alignment) char memory[4096]; // should use multiple chunks
-        check_list(list, memory, 4096);
+        static_allocator_storage<4096> memory; // should use multiple chunks
+        check_list(list, &memory, 4096);
     }
     SECTION("multiple insert")
     {
-        alignas(max_alignment) char a[1024], b[100], c[1337];
-        check_list(list, a, 1024);
-        check_list(list, b, 100);
-        check_list(list, c, 1337);
+        static_allocator_storage<1024> a;
+        static_allocator_storage<100> b;
+        static_allocator_storage<1337> c;
+        check_list(list, &a, 1024);
+        check_list(list, &b, 100);
+        check_list(list, &c, 1337);
     }
     check_move(list);
 }

--- a/test/detail/free_list_array.cpp
+++ b/test/detail/free_list_array.cpp
@@ -8,6 +8,7 @@
 
 #include "detail/free_list.hpp"
 #include "detail/small_free_list.hpp"
+#include "static_allocator.hpp"
 
 using namespace foonathan::memory;
 using namespace detail;
@@ -32,8 +33,8 @@ TEST_CASE("detail::log2_access_policy", "[detail][pool]")
 
 TEST_CASE("detail::free_list_array", "[detail][pool]")
 {
-    alignas(max_alignment) char memory[1024];
-    detail::fixed_memory_stack stack(memory, 1024);
+    static_allocator_storage<1024> memory;
+    detail::fixed_memory_stack stack(&memory, 1024);
     SECTION("power of two max size, small list")
     {
         using array = detail::free_list_array<detail::small_free_memory_list,


### PR DESCRIPTION
* new_allocator is unchanged
* improve heap_allocator on Windows to use HeapAlloc
* add malloc_allocator on hosted implementation that always uses malloc()
* add static_allocator allocating from a fixed sized storage, e.g. on the stack
* add (experimental) interface for allocating virtual memory
* add virtual_memory_allocator using this interface
* make all of them possible candidates for default_allocator
* add unit tests and fix alignment bugs with fence memory