### PR TITLE
Fixed bug that sets the size of a memory block to 0 in fixed_block_allocator

### DIFF
--- a/include/foonathan/memory/memory_arena.hpp
+++ b/include/foonathan/memory/memory_arena.hpp
@@ -507,8 +507,9 @@ namespace foonathan { namespace memory
             {
                 auto mem = traits::allocate_array(get_allocator(), block_size_,
                                                   1, detail::max_alignment);
+                memory_block block(mem, block_size_);
                 block_size_ = 0u;
-                return {mem, block_size_};
+                return block;
             }
             FOONATHAN_THROW(out_of_fixed_memory(info(), block_size_));
         }


### PR DESCRIPTION
It set the block_size of the returned block to a very large integer, causing a segfault when doing something like:
```

typedef foonathan::memory::memory_pool<foonathan::memory::node_pool, foonathan::memory::fixed_block_allocator<> > Memory;
typedef foonathan::memory::std_allocator<T, Memory, foonathan::memory::no_mutex> Allocator;

Memory* const pool = new Memory(80, <some large number>); // allocate memory pool of N bytes
```

It is now conform growing_block_allocator

Edit: I'm realising I should've pulled it to your develop branch... sorry, quite new with this