### PR TITLE
Bump version number to 0.6

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ cmake_minimum_required(VERSION 3.1)
 project(FOONATHAN_MEMORY)
 
 set(FOONATHAN_MEMORY_VERSION_MAJOR 0 CACHE STRING "major version of memory" FORCE)
-set(FOONATHAN_MEMORY_VERSION_MINOR 5 CACHE STRING "minor version of memory" FORCE)
+set(FOONATHAN_MEMORY_VERSION_MINOR 6 CACHE STRING "minor version of memory" FORCE)
 set(FOONATHAN_MEMORY_VERSION "${FOONATHAN_MEMORY_VERSION_MAJOR}.${FOONATHAN_MEMORY_VERSION_MINOR}"
                              CACHE STRING "version of memory" FORCE)
 


### PR DESCRIPTION
Version 0.6 has been released but directory name is still 0.5. 
Nothing more than that.

If this gets merged in master it should be better to update the tag in order to match the correct git hash or issue another version tag completely (something like 0.6a?) 