### PR TITLE
The node debugger tries to create too many sections in the obj-file.

### DIFF
--- a/tool/CMakeLists.txt
+++ b/tool/CMakeLists.txt
@@ -7,6 +7,9 @@
 add_executable(foonathan_memory_node_size_debugger test_types.hpp node_size_debugger.hpp node_size_debugger.cpp)
 _foonathan_use_comp(foonathan_memory_node_size_debugger)
 comp_target_features(foonathan_memory_node_size_debugger PUBLIC CPP11)
+if (MSVC)
+    target_compile_options(foonathan_memory_node_size_debugger PRIVATE "/bigobj")
+endif()
 target_compile_definitions(foonathan_memory_node_size_debugger PUBLIC
                            VERSION="${FOONATHAN_MEMORY_VERSION_MAJOR}.${FOONATHAN_MEMORY_VERSION_MINOR}")
 set_target_properties(foonathan_memory_node_size_debugger PROPERTIES OUTPUT_NAME nodesize_dbg)


### PR DESCRIPTION
Accommodate by using the '/bigobj' flag, otherwise compilation fails in debug-mode.
  