### PR TITLE
Replace MSVC related C++17 warnings

### DIFF
--- a/include/foonathan/memory/malloc_allocator.hpp
+++ b/include/foonathan/memory/malloc_allocator.hpp
@@ -47,7 +47,7 @@ namespace foonathan
 
                 static std::size_t max_node_size() FOONATHAN_NOEXCEPT
                 {
-                    return std::allocator<char>().max_size();
+                    return std::allocator_traits<std::allocator<char>>::max_size({});
                 }
             };
 

--- a/src/detail/align.cpp
+++ b/src/detail/align.cpp
@@ -18,5 +18,5 @@ bool foonathan::memory::detail::is_aligned(void *ptr, std::size_t alignment) FOO
 
 std::size_t foonathan::memory::detail::alignment_for(std::size_t size) FOONATHAN_NOEXCEPT
 {
-    return size >= max_alignment ? max_alignment : (1 << ilog2(size));
+    return size >= max_alignment ? max_alignment : (std::size_t(1) << ilog2(size));
 }

--- a/src/detail/free_list_array.cpp
+++ b/src/detail/free_list_array.cpp
@@ -18,5 +18,5 @@ std::size_t log2_access_policy::index_from_size(std::size_t size) FOONATHAN_NOEX
 
 std::size_t log2_access_policy::size_from_index(std::size_t index) FOONATHAN_NOEXCEPT
 {
-    return 1 << index;
+    return std::size_t(1) << index;
 }

--- a/src/heap_allocator.cpp
+++ b/src/heap_allocator.cpp
@@ -54,7 +54,7 @@ namespace
 {
     std::size_t max_size() FOONATHAN_NOEXCEPT
     {
-        return std::allocator<char>().max_size();
+        return std::allocator_traits<std::allocator<char>>::max_size({});
     }
 }
 #else

--- a/src/new_allocator.cpp
+++ b/src/new_allocator.cpp
@@ -57,7 +57,7 @@ void detail::new_allocator_impl::deallocate(void* ptr, std::size_t, size_t) FOON
 std::size_t detail::new_allocator_impl::max_node_size() FOONATHAN_NOEXCEPT
 {
 #if FOONATHAN_HOSTED_IMPLEMENTATION
-    return std::allocator<char>().max_size();
+    return std::allocator_traits<std::allocator<char>>::max_size({});
 #else
     return std::size_t(-1);
 #endif


### PR DESCRIPTION
Doing some experiments with C++17 reveiled some deprecation warnings on MSVC. Even if not critical, I took the liberty to propose a few small fixes.

* Replace deprecated allocator method with trait methods
* Use explicitly typed constants for shifting