### PR TITLE
Export all symbols when built as shared library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,6 +45,7 @@ elseif(WIN32)
 
     set(FOONATHAN_MEMORY_CMAKE_CONFIG_INSTALL_DIR "cmake")
     set(FOONATHAN_MEMORY_ADDITIONAL_FILES_INSTALL_DIR "./")
+    set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
 else()
 	message(FATAL_ERROR "Could not set install folders for this platform!")
 endif()


### PR DESCRIPTION
When built as a shared library on Win32, a `.lib` file will not be created if no symbols is exported.

This patch try to fix this issue.