### PR TITLE
Fix debug helper test for build type RelWithDebInfo

### DIFF
--- a/test/detail/debug_helpers.cpp
+++ b/test/detail/debug_helpers.cpp
@@ -55,19 +55,26 @@ TEST_CASE("detail::debug_fill_new/free", "[detail][core]")
     REQUIRE(offset == expected_offset);
 
 #if FOONATHAN_MEMORY_DEBUG_FILL
+#if FOONATHAN_MEMORY_DEBUG_FENCE
     REQUIRE(array[0] == debug_magic::fence_memory);
-    for (auto i = 1; i <= 8; ++i)
-        REQUIRE(array[i] == debug_magic::new_memory);
     REQUIRE(array[9] == debug_magic::fence_memory);
+    const auto start = 1;
+#else
+    const auto start = 0;
+#endif
+    for (auto i = start; i < start + 8; ++i)
+        REQUIRE(array[i] == debug_magic::new_memory);
 #endif
 
     result = debug_fill_free(result, 8 * sizeof(debug_magic), sizeof(debug_magic));
     REQUIRE(static_cast<debug_magic*>(result) == array);
 
 #if FOONATHAN_MEMORY_DEBUG_FILL
+#if FOONATHAN_MEMORY_DEBUG_FENCE
     REQUIRE(array[0] == debug_magic::fence_memory);
-    for (auto i = 1; i <= 8; ++i)
-        REQUIRE(array[i] == debug_magic::freed_memory);
     REQUIRE(array[9] == debug_magic::fence_memory);
+#endif
+    for (auto i = start; i < start + 8; ++i)
+        REQUIRE(array[i] == debug_magic::freed_memory);
 #endif
 }


### PR DESCRIPTION
Tests fail on master when the library is built with the `RelWithDebInfo` build type.

Reproducing:

```
# clone
mkdir build
cd build
cmake .. -DCMAKE_BUILD_TYPE=RelWithDebInfo
make
./test/foonathan_memory_test
```

Output:

```
Filters:

~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
foonathan_memory_test is a Catch v2.7.1 host application.
Run with -? for options

-------------------------------------------------------------------------------
detail::debug_fill_new/free
-------------------------------------------------------------------------------
/home/christopher.ho/cho3_ws/memory/test/detail/debug_helpers.cpp:48
...............................................................................

/home/christopher.ho/cho3_ws/memory/test/detail/debug_helpers.cpp:58: FAILED:
  REQUIRE( array[0] == debug_magic::fence_memory )
with expansion:
  ' == '�'

===============================================================================
test cases:   36 |   35 passed | 1 failed
assertions: 9780 | 9779 passed | 1 failed

```

This occurs because the `FOONATHAN_DEBUG_FENCE_SIZE` is set to `0`, but the test does not properly check if this variable is properly populated.

This PR fixes this issue by adding additional logic for the failing test.