### PR TITLE
Fix VS2015 warnings

### DIFF
--- a/include/foonathan/memory/std_allocator.hpp
+++ b/include/foonathan/memory/std_allocator.hpp
@@ -224,6 +224,8 @@ namespace foonathan
             template <typename U>
             void destroy(U* p) FOONATHAN_NOEXCEPT
             {
+                // This is to avoid a MSVS 2015 'unreferenced formal parameter' warning
+                (void)p;
                 p->~U();
             }
 


### PR DESCRIPTION
I am using your library in a project that builds with MSVS 2015 and it throws unused reference warnings.

This PR fixes the issue.