### PR TITLE
Fix cmake paths

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,9 +18,6 @@ set(FOONATHAN_MEMORY_VERSION "${FOONATHAN_MEMORY_VERSION_MAJOR}.${FOONATHAN_MEMO
 set(CMAKE_DEBUG_POSTFIX "-dbg")
 
 # installation destinations
-if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
-    set(CMAKE_INSTALL_PREFIX "${CMAKE_BINARY_DIR}/install" CACHE STRING "Install prefix (e.g. /usr/local/)" FORCE)
-endif()
 if(UNIX)
     include(GNUInstallDirs)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -111,7 +111,7 @@ install(TARGETS foonathan_memory EXPORT foonathan_memoryTargets
 
 # Write/install version file
 include(CMakePackageConfigHelpers)
-set(version_file "${CMAKE_CURRENT_BINARY_DIR}/cmake/foonathan_memory-version.cmake")
+set(version_file "${CMAKE_CURRENT_BINARY_DIR}/cmake/foonathan_memory-config-version.cmake")
 write_basic_package_version_file(${version_file}
                                  VERSION ${FOONATHAN_MEMORY_VERSION}
                                  COMPATIBILITY AnyNewerVersion)


### PR DESCRIPTION
- Removes overriding of `CMAKE_INSTALL_PREFIX` from OS defaults.
Fixes #48 

- Fixes name of the cmake version file generated so that available version can be detected by find_package
Fixes #54 
