### PR TITLE
Fix cmake crosscompiling

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -77,9 +77,9 @@ set(src
 configure_file("config.hpp.in" "${CMAKE_CURRENT_BINARY_DIR}/config_impl.hpp")
 
 # generate container_node_sizes.hpp
-if(FOONATHAN_MEMORY_BUILD_TOOLS AND (NOT CMAKE_CROSSCOMPILING))
+if(FOONATHAN_MEMORY_BUILD_TOOLS)
     add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/container_node_sizes_impl.hpp
-            COMMAND foonathan_memory_node_size_debugger --code --alignof "FOONATHAN_ALIGNOF(T)" ${CMAKE_CURRENT_BINARY_DIR}/container_node_sizes_impl.hpp
+            COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} ${CMAKE_BINARY_DIR}/tool/nodesize_dbg --code --alignof "FOONATHAN_ALIGNOF(T)" ${CMAKE_CURRENT_BINARY_DIR}/container_node_sizes_impl.hpp
             DEPENDS foonathan_memory_node_size_debugger
             VERBATIM)
 else()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -79,7 +79,7 @@ configure_file("config.hpp.in" "${CMAKE_CURRENT_BINARY_DIR}/config_impl.hpp")
 # generate container_node_sizes.hpp
 if(FOONATHAN_MEMORY_BUILD_TOOLS)
     add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/container_node_sizes_impl.hpp
-            COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} ${CMAKE_BINARY_DIR}/tool/nodesize_dbg --code --alignof "FOONATHAN_ALIGNOF(T)" ${CMAKE_CURRENT_BINARY_DIR}/container_node_sizes_impl.hpp
+            COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} $<TARGET_FILE:foonathan_memory_node_size_debugger> --code --alignof "FOONATHAN_ALIGNOF(T)" ${CMAKE_CURRENT_BINARY_DIR}/container_node_sizes_impl.hpp
             DEPENDS foonathan_memory_node_size_debugger
             VERBATIM)
 else()

--- a/tool/CMakeLists.txt
+++ b/tool/CMakeLists.txt
@@ -5,7 +5,10 @@
 # builds tools
 
 add_executable(foonathan_memory_node_size_debugger test_types.hpp node_size_debugger.hpp node_size_debugger.cpp)
-set_target_properties(foonathan_memory_node_size_debugger PROPERTIES LINK_FLAGS "-static")
+if (CMAKE_CROSSCOMPILING)
+    # statically link when cross compiling so emulator doesn't need library paths
+    set_target_properties(foonathan_memory_node_size_debugger PROPERTIES LINK_FLAGS "-static")
+endif()
 _foonathan_use_comp(foonathan_memory_node_size_debugger)
 comp_target_features(foonathan_memory_node_size_debugger PUBLIC CPP11)
 if (MSVC)

--- a/tool/CMakeLists.txt
+++ b/tool/CMakeLists.txt
@@ -5,6 +5,7 @@
 # builds tools
 
 add_executable(foonathan_memory_node_size_debugger test_types.hpp node_size_debugger.hpp node_size_debugger.cpp)
+set_target_properties(foonathan_memory_node_size_debugger PROPERTIES LINK_FLAGS "-static")
 _foonathan_use_comp(foonathan_memory_node_size_debugger)
 comp_target_features(foonathan_memory_node_size_debugger PUBLIC CPP11)
 if (MSVC)


### PR DESCRIPTION
This fix allows foonathan/memory to build correctly with all nodesize features when crosscompiling.  It builds the nodesize_dbg tool and links it statically to avoid anoying library search paths.  Then it uses the crosscompiling emulator provided by the toolchain file to run nodesize_dbg and generate container_node_sizes_impl.hpp during the build.

For this to work the toolchain file must provide the emulator executable

Example aarch64-linux-gnu.cmake toolchain file
```
# 64 bit ARM (aarch64)

# use it like this:
# cmake -DCMAKE_TOOLCHAIN_FILE=/path/to/toolchain.cmake <sourcedir>

# set the name of the target system
set(CMAKE_SYSTEM_NAME "Linux" CACHE STRING "Target system")
set(CMAKE_SYSTEM_PROCESSOR "aarch64" CACHE STRING "Target architecture")

# set the compiler
set(CMAKE_LIBRARY_ARCHITECTURE "aarch64-linux-gnu")
set(CMAKE_C_COMPILER   "${CMAKE_LIBRARY_ARCHITECTURE}-gcc")
set(CMAKE_CXX_COMPILER "${CMAKE_LIBRARY_ARCHITECTURE}-g++")
set(CMAKE_LINKER       "${CMAKE_LIBRARY_ARCHITECTURE}-ld")

# where is the target environment located
# this should be a chroot environment on your system with all the required native libraries
set(CMAKE_FIND_ROOT_PATH "/usr/local/targets/${CMAKE_LIBRARY_ARCHITECTURE}")
include_directories("${CMAKE_FIND_ROOT_PATH}/usr/include/${CMAKE_LIBRARY_ARCHITECTURE}")

# adjust the default behaviour of the FIND_XXX() commands:
# search for programs in the host environment
# search for headers and libraries in the target environment 
set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)

# crosscompiling emulator ( cmake > 3.4 )
# This variable is only used when CMAKE_CROSSCOMPILING is on.
# It should point to a command on the host system that can run
# executables built for the target system. The command will also be
# used to run try_run() generated executables, which avoids 
# manual population of the TryRunResults.cmake file.
# It is also used as the default value for the CROSSCOMPILING_EMULATOR
# target property of executables.

# not required on x86_64 systems running i386 code

set(CMAKE_CROSSCOMPILING_EMULATOR /usr/bin/qemu-${CMAKE_SYSTEM_PROCESSOR})
```