### PR TITLE
build fix: add -fPIC when build foonathan_memory library

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -101,7 +101,8 @@ target_compile_definitions(foonathan_memory PUBLIC
                             FOONATHAN_MEMORY_VERSION_PATCH=${FOONATHAN_MEMORY_VERSION_PATCH})
 
 set_target_properties(foonathan_memory PROPERTIES
-                                       OUTPUT_NAME "foonathan_memory-${FOONATHAN_MEMORY_VERSION}")
+                                       OUTPUT_NAME "foonathan_memory-${FOONATHAN_MEMORY_VERSION}"
+                                       POSITION_INDEPENDENT_CODE ON)
 
 install(TARGETS foonathan_memory EXPORT foonathan_memoryTargets
         RUNTIME       DESTINATION ${FOONATHAN_MEMORY_RUNTIME_INSTALL_DIR}


### PR DESCRIPTION
ERROR message:
libfoonathan_memory-0.6.2.a(error.cpp.o): relocation
R_AARCH64_ADR_PREL_PG_HI21 against symbol `stderr@@GLIBC_2.17' which may
bind externally can not be used when making a shared object; recompile
with -fPIC