### PR TITLE
Fixed warnings on non-gnuc 32 bit systems

### DIFF
--- a/include/foonathan/memory/detail/ilog2.hpp
+++ b/include/foonathan/memory/detail/ilog2.hpp
@@ -30,8 +30,8 @@ namespace foonathan
                 return sizeof(value) * CHAR_BIT - __builtin_clzll(value);
 #else
                 // Adapted from https://stackoverflow.com/a/40943402
-                std::size_t   clz = 64;
-                std::uint64_t c   = 32;
+                std::size_t clz = 64;
+                std::size_t c   = 32;
                 do
                 {
                     auto tmp = x >> c;
@@ -42,7 +42,7 @@ namespace foonathan
                     }
                     c = c >> 1;
                 } while (c != 0);
-                clz -= x;
+                clz -= x ? 1 : 0;
 
                 return 64 - clz;
 #endif


### PR DESCRIPTION
I'm getting warnings on Visual Studio when building for 32 bits after commit 293f88d3a7cc49b25ffd4e9f27b1e4a8e14ee0d7 

```
include\foonathan\memory\detail/ilog2.hpp(40): warning C4244: '-=': conversion from 'uint64_t' to 'std::size_t', possible loss of data
include\foonathan\memory\detail/ilog2.hpp(45): warning C4244: '-=': conversion from 'uint64_t' to 'std::size_t', possible loss of data
```

I haven't checked yet, but this could also be the case on other non-gnuc building environments.