### PR TITLE
Modification for making Foonathan memory compatible with UWP

### DIFF
--- a/src/virtual_memory.cpp
+++ b/src/virtual_memory.cpp
@@ -37,7 +37,7 @@ const std::size_t foonathan::memory::virtual_memory_page_size = get_page_size();
 void* foonathan::memory::virtual_memory_reserve(std::size_t no_pages) noexcept
 {
     auto pages =
-        VirtualAlloc(nullptr, no_pages * virtual_memory_page_size, MEM_RESERVE, PAGE_READWRITE);
+        VirtualAllocFromApp(nullptr, no_pages * virtual_memory_page_size, MEM_RESERVE, PAGE_READWRITE);
     return pages;
 }
 
@@ -51,7 +51,7 @@ void* foonathan::memory::virtual_memory_commit(void*       memory,
                                                std::size_t no_pages) noexcept
 {
     auto region =
-        VirtualAlloc(memory, no_pages * virtual_memory_page_size, MEM_COMMIT, PAGE_READWRITE);
+        VirtualAllocFromApp(memory, no_pages * virtual_memory_page_size, MEM_COMMIT, PAGE_READWRITE);
     if (!region)
         return nullptr;
     FOONATHAN_MEMORY_ASSERT(region == memory);

--- a/src/virtual_memory.cpp
+++ b/src/virtual_memory.cpp
@@ -39,10 +39,10 @@ void* foonathan::memory::virtual_memory_reserve(std::size_t no_pages) noexcept
 {
     auto pages =
     #if WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP)
-		VirtualAlloc(nullptr, no_pages * virtual_memory_page_size, MEM_RESERVE, PAGE_READWRITE);
-	#else
+        VirtualAlloc(nullptr, no_pages * virtual_memory_page_size, MEM_RESERVE, PAGE_READWRITE);
+    #else
         VirtualAllocFromApp(nullptr, no_pages * virtual_memory_page_size, MEM_RESERVE, PAGE_READWRITE);
-	#endif
+    #endif
     return pages;
 }
 
@@ -57,10 +57,10 @@ void* foonathan::memory::virtual_memory_commit(void*       memory,
 {
     auto region =
     #if WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP)
-		VirtualAlloc(memory, no_pages * virtual_memory_page_size, MEM_COMMIT, PAGE_READWRITE);
-	#else
+        VirtualAlloc(memory, no_pages * virtual_memory_page_size, MEM_COMMIT, PAGE_READWRITE);
+    #else
         VirtualAllocFromApp(memory, no_pages * virtual_memory_page_size, MEM_COMMIT, PAGE_READWRITE);
-	#endif
+    #endif
     if (!region)
         return nullptr;
     FOONATHAN_MEMORY_ASSERT(region == memory);

--- a/src/virtual_memory.cpp
+++ b/src/virtual_memory.cpp
@@ -19,7 +19,6 @@ void detail::virtual_memory_allocator_leak_handler::operator()(std::ptrdiff_t am
 
 #if defined(_WIN32)
 #include <windows.h>
-#include <winapifamily.h>
 
 namespace
 {
@@ -38,7 +37,7 @@ const std::size_t foonathan::memory::virtual_memory_page_size = get_page_size();
 void* foonathan::memory::virtual_memory_reserve(std::size_t no_pages) noexcept
 {
     auto pages =
-    #if WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP)
+    #if (_MSC_VER <= 1900)
         VirtualAlloc(nullptr, no_pages * virtual_memory_page_size, MEM_RESERVE, PAGE_READWRITE);
     #else
         VirtualAllocFromApp(nullptr, no_pages * virtual_memory_page_size, MEM_RESERVE, PAGE_READWRITE);
@@ -56,7 +55,7 @@ void* foonathan::memory::virtual_memory_commit(void*       memory,
                                                std::size_t no_pages) noexcept
 {
     auto region =
-    #if WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP)
+    #if (_MSC_VER <= 1900)
         VirtualAlloc(memory, no_pages * virtual_memory_page_size, MEM_COMMIT, PAGE_READWRITE);
     #else
         VirtualAllocFromApp(memory, no_pages * virtual_memory_page_size, MEM_COMMIT, PAGE_READWRITE);

--- a/tool/CMakeLists.txt
+++ b/tool/CMakeLists.txt
@@ -7,7 +7,7 @@
 add_executable(foonathan_memory_node_size_debugger test_types.hpp node_size_debugger.hpp node_size_debugger.cpp)
 if (CMAKE_CROSSCOMPILING)
     # statically link when cross compiling so emulator doesn't need library paths
-    set_target_properties(foonathan_memory_node_size_debugger PROPERTIES LINK_FLAGS "-static")
+    set_target_properties(foonathan_memory_node_size_debugger PROPERTIES LINK_FLAGS "/WHOLEARCHIVE")
 endif()
 if (MSVC)
     target_compile_options(foonathan_memory_node_size_debugger PRIVATE "/bigobj")


### PR DESCRIPTION
Modifications to VirtualAlloc for Windows compilation, so that it is compatible with UWP. In particular: `VirtualAlloc` was changed to `VirtualAllocFromApp` so that it is compatible for both Windows Desktop and UWP (https://docs.microsoft.com/en-us/windows/win32/api/memoryapi/nf-memoryapi-virtualallocfromapp). In addition, in the CMakeLists.txt, `-static` option was changed to `/wholearchive` as `-static` does not work anymore (please see https://docs.microsoft.com/en-us/cpp/build/reference/linker-options?view=vs-2019).

This has been tested on both current Visual Studio 2017 and 2019.