### PR TITLE
Added method for minimum block size of a memory_pool

### DIFF
--- a/include/foonathan/memory/memory_pool.hpp
+++ b/include/foonathan/memory/memory_pool.hpp
@@ -60,13 +60,17 @@ namespace foonathan
             /// and \c number_of_nodes must be a non-zero value.
             static constexpr std::size_t min_block_size(std::size_t node_size, std::size_t number_of_nodes)
             {
+                size_t per_node_size = node_size;
+                // Ensure at least min_node_size bytes per node
+                if (node_size < min_node_size)
+                    per_node_size = min_node_size;
+                // Take additional debug space into account
+                if (detail::debug_fence_size)
+                    per_node_size += 2 * detail::max_alignment;
+
                 return
                     detail::memory_block_stack::implementation_offset +
-                    number_of_nodes *
-                    (
-                        ( (node_size > min_node_size) ? node_size : min_node_size) +
-                        detail::debug_fence_size ? 2 * detail::max_alignment : 0
-                    );
+                    number_of_nodes * per_node_size;
             }
 
             /// \effects Creates it by specifying the size each \concept{concept_node,node} will have,

--- a/include/foonathan/memory/memory_pool.hpp
+++ b/include/foonathan/memory/memory_pool.hpp
@@ -61,8 +61,8 @@ namespace foonathan
             /// \returns The minimum block size required for certain number of \concept{concept_node,node}.
             /// \requires \c node_size must be a valid \concept{concept_node,node size}
             /// and \c number_of_nodes must be a non-zero value.
-            static constexpr std::size_t min_block_size(std::size_t node_size,
-                                                        std::size_t number_of_nodes)
+            static const std::size_t min_block_size(std::size_t node_size,
+                                                    std::size_t number_of_nodes) noexcept
             {
                 size_t per_node_size = node_size;
                 // Ensure at least min_node_size bytes per node

--- a/include/foonathan/memory/memory_pool.hpp
+++ b/include/foonathan/memory/memory_pool.hpp
@@ -61,19 +61,13 @@ namespace foonathan
             /// \returns The minimum block size required for certain number of \concept{concept_node,node}.
             /// \requires \c node_size must be a valid \concept{concept_node,node size}
             /// and \c number_of_nodes must be a non-zero value.
-            static const std::size_t min_block_size(std::size_t node_size,
-                                                    std::size_t number_of_nodes) noexcept
+            static constexpr std::size_t min_block_size(std::size_t node_size,
+                                                        std::size_t number_of_nodes) noexcept
             {
-                size_t per_node_size = node_size;
-                // Ensure at least min_node_size bytes per node
-                if (node_size < min_node_size)
-                    per_node_size = min_node_size;
-                // Take additional debug space into account
-                if (detail::debug_fence_size)
-                    per_node_size += 2 * detail::max_alignment;
-
-                return detail::memory_block_stack::implementation_offset
-                       + number_of_nodes * per_node_size;
+                return detail::memory_block_stack::implementation_offset()
+                       + number_of_nodes
+                             * (((node_size > min_node_size) ? node_size : min_node_size)
+                                + (detail::debug_fence_size ? 2 * detail::max_alignment : 0));
             }
 
             /// \effects Creates it by specifying the size each \concept{concept_node,node} will have,

--- a/include/foonathan/memory/memory_pool.hpp
+++ b/include/foonathan/memory/memory_pool.hpp
@@ -54,6 +54,20 @@ namespace foonathan
 
             static constexpr std::size_t min_node_size =
                 FOONATHAN_IMPL_DEFINED(free_list::min_element_size);
+                
+            /// \returns The minimum block size required for certain number of \concept{concept_node,node}.
+            /// \requires \c node_size must be a valid \concept{concept_node,node size}
+            /// and \c number_of_nodes must be a non-zero value.
+            static constexpr std::size_t min_block_size(std::size_t node_size, std::size_t number_of_nodes)
+            {
+                return
+                    detail::memory_block_stack::implementation_offset +
+                    number_of_nodes *
+                    (
+                        ( (node_size > min_node_size) ? node_size : min_node_size) +
+                        detail::debug_fence_size ? 2 * detail::max_alignment : 0
+                    );
+            }
 
             /// \effects Creates it by specifying the size each \concept{concept_node,node} will have,
             /// the initial block size for the arena and other constructor arguments for the \concept{concept_blockallocator,BlockAllocator}.

--- a/include/foonathan/memory/memory_pool.hpp
+++ b/include/foonathan/memory/memory_pool.hpp
@@ -57,11 +57,12 @@ namespace foonathan
 
             static constexpr std::size_t min_node_size =
                 FOONATHAN_IMPL_DEFINED(free_list::min_element_size);
-                
+
             /// \returns The minimum block size required for certain number of \concept{concept_node,node}.
             /// \requires \c node_size must be a valid \concept{concept_node,node size}
             /// and \c number_of_nodes must be a non-zero value.
-            static std::size_t min_block_size(std::size_t node_size, std::size_t number_of_nodes)
+            static constexpr std::size_t min_block_size(std::size_t node_size,
+                                                        std::size_t number_of_nodes)
             {
                 size_t per_node_size = node_size;
                 // Ensure at least min_node_size bytes per node
@@ -71,9 +72,8 @@ namespace foonathan
                 if (detail::debug_fence_size)
                     per_node_size += 2 * detail::max_alignment;
 
-                return
-                    detail::memory_block_stack::implementation_offset +
-                    number_of_nodes * per_node_size;
+                return detail::memory_block_stack::implementation_offset
+                       + number_of_nodes * per_node_size;
             }
 
             /// \effects Creates it by specifying the size each \concept{concept_node,node} will have,

--- a/include/foonathan/memory/memory_pool.hpp
+++ b/include/foonathan/memory/memory_pool.hpp
@@ -5,6 +5,9 @@
 #ifndef FOONATHAN_MEMORY_MEMORY_POOL_HPP_INCLUDED
 #define FOONATHAN_MEMORY_MEMORY_POOL_HPP_INCLUDED
 
+// Inform that foonathan::memory::memory_pool::min_block_size API is available
+#define FOONATHAN_MEMORY_MEMORY_POOL_HAS_MIN_BLOCK_SIZE
+
 /// \file
 /// Class \ref foonathan::memory::memory_pool and its \ref foonathan::memory::allocator_traits specialization.
 

--- a/include/foonathan/memory/memory_pool.hpp
+++ b/include/foonathan/memory/memory_pool.hpp
@@ -61,7 +61,7 @@ namespace foonathan
             /// \returns The minimum block size required for certain number of \concept{concept_node,node}.
             /// \requires \c node_size must be a valid \concept{concept_node,node size}
             /// and \c number_of_nodes must be a non-zero value.
-            static constexpr std::size_t min_block_size(std::size_t node_size, std::size_t number_of_nodes)
+            static std::size_t min_block_size(std::size_t node_size, std::size_t number_of_nodes)
             {
                 size_t per_node_size = node_size;
                 // Ensure at least min_node_size bytes per node


### PR DESCRIPTION
When the user knows the number of nodes going to be used in a collection, it would be nice to have a way to calculate the exact size required on one memory block, so allocation of additional blocks is not required

Signed-off-by: Miguel Company <MiguelCompany@eprosima.com>