### PR TITLE
disable autogen of header for QNX on Linux & provide a user config pa…

### DIFF
--- a/cmake/configuration.cmake
+++ b/cmake/configuration.cmake
@@ -69,3 +69,5 @@ option(FOONATHAN_MEMORY_EXTERN_TEMPLATE
     "whether or not common template instantiations are already provided by the library" ON)
 set(FOONATHAN_MEMORY_TEMPORARY_STACK_MODE 2 CACHE STRING
      "set to 0 to disable the per-thread stack completely, to 1 to disable the nitfy counter and to 2 to enable everything")
+set(FOONATHAN_MEMORY_CONTAINER_NODE_SIZES_IMPL container_node_sizes_impl.hpp CACHE FILEPATH
+     "the path of the header that defines the node sizes and alignments if pre-generated.")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -89,26 +89,20 @@ if(FOONATHAN_MEMORY_BUILD_TOOLS)
             COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} $<TARGET_FILE:foonathan_memory_node_size_debugger> --code ${CMAKE_CURRENT_BINARY_DIR}/container_node_sizes_impl.hpp
             DEPENDS foonathan_memory_node_size_debugger
             VERBATIM)
-    elseif(QNX OR QNXNTO)
-    # currently this process was only tested on Linux and Windows. Linux matched the QNX generated header file but Windows did not
-    # Mac still needs to be tested. If passed the test then could be added here as well.
-    if( CMAKE_HOST_SYSTEM_NAME STREQUAL "Linux" AND NOT CMAKE_SYSTEM_PROCESSOR STREQUAL "armv7")
-      execute_process(COMMAND g++ -DVERSION="${FOONATHAN_MEMORY_VERSION_MAJOR}.${FOONATHAN_MEMORY_VERSION_MINOR}.${FOONATHAN_MEMORY_VERSION_PATCH}" -o ${PROJECT_SOURCE_DIR}/tool/nodesize_dbg ${PROJECT_SOURCE_DIR}/tool/node_size_debugger.cpp )
+  elseif(QNX OR QNXNTO)
+    if(EXISTS "${FOONATHAN_MEMORY_CONTAINER_NODE_SIZES_IMPL}")
+      message("-- Using the pre-generated file: ${FOONATHAN_MEMORY_CONTAINER_NODE_SIZES_IMPL}")
       add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/container_node_sizes_impl.hpp
-              COMMAND ${PROJECT_SOURCE_DIR}/tool/nodesize_dbg --code ${CMAKE_CURRENT_BINARY_DIR}/container_node_sizes_impl.hpp)
-    elseif(EXISTS "${PROJECT_SOURCE_DIR}/tool/container_node_sizes_impl.hpp")
-      message("-- Using manually generated file: tool/container_node_sizes_impl.hpp")
-      add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/container_node_sizes_impl.hpp
-              COMMAND cp ${PROJECT_SOURCE_DIR}/tool/container_node_sizes_impl.hpp ${CMAKE_CURRENT_BINARY_DIR}/container_node_sizes_impl.hpp )
+            COMMAND cp ${FOONATHAN_MEMORY_CONTAINER_NODE_SIZES_IMPL} ${CMAKE_CURRENT_BINARY_DIR}/container_node_sizes_impl.hpp )
     else()
-      message(FATAL_ERROR "\nCannot generate container_node_sizes_impl.hpp on ${CMAKE_HOST_SYSTEM_NAME}.\n"
-                            "Please manually generate the header file container_node_sizes_impl.hpp by doing the following:\n"
+      message(FATAL_ERROR "\nError: Cannot find pre-generated file container_node_sizes_impl.hpp\n"
+                            "Please pre-generate the header file container_node_sizes_impl.hpp by following the steps below:\n"
                             "- Build nodesize_dbg from source:\n"
                             "	${PROJECT_SOURCE_DIR}/tool/node_size_debugger.cpp \n"
-                            "- Transfer file to QNX target and execute:\n"
-                            "	nodesize_dbg --code > container_node_sizes_impl.hpp \n"
-                            "- Transfer generated header file back to: \n"
-                            "	${PROJECT_SOURCE_DIR}/tool and REBUILD")
+                            "- Transfer nodesize_dbg to QNX target and execute:\n"
+                            "	nodesize_dbg --code container_node_sizes_impl.hpp \n"
+                            "- Transfer generated header file back to your development system \n" 
+                            "- Set FOONATHAN_MEMORY_CONTAINER_NODE_SIZES_IMPL to the path of the pre-generated file and pass it to cmake as an argument\n")
     endif()
   else()
     message(WARNING "cross-compiling, but emulator is not defined, "


### PR DESCRIPTION
…th for a pregen container_node_sizes_impl.hpp

Fixes #91 

- add FOONATHAN_MEMORY_CONTAINER_NODE_SIZES_IMPL which provides a way to the developer to pass the path of the pre-generated file container_node_sizes_impl.hpp

- disable autogen of header file on linux for QNX since it has proven to be not flexible and could lead to issues.
- update error msg if container_node_sizes_impl.hpp is not found when cross compiling for QNX
