### PR TITLE
Link against libatomic if needed

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,6 +44,7 @@ else()
 endif()
 
 include(cmake/configuration.cmake)
+include(cmake/atomic.cmake)
 
 # subdirectories
 add_subdirectory(src)

--- a/cmake/atomic.cmake
+++ b/cmake/atomic.cmake
@@ -1,0 +1,21 @@
+# check for atomic library, which is needed on some architectures
+include(CheckCXXSourceCompiles)
+function(check_working_cxx_atomic varname)
+	check_cxx_source_compiles("
+	#include <atomic>
+	std::atomic<bool> x;
+	int main() {
+		bool y = false;
+		return !x.compare_exchange_strong(y, true);
+	}" ${varname})
+endfunction()
+check_working_cxx_atomic(HAVE_CXX_ATOMIC)
+if(NOT HAVE_CXX_ATOMIC)
+	set(old_CMAKE_REQUIRED_LIBRARIES "${CMAKE_REQUIRED_LIBRARIES}")
+	list(APPEND CMAKE_REQUIRED_LIBRARIES "-latomic")
+	check_working_cxx_atomic(NEED_LIBRARY_FOR_CXX_ATOMIC)
+	set(CMAKE_REQUIRED_LIBRARIES "${old_CMAKE_REQUIRED_LIBRARIES}")
+	if(NOT NEED_LIBRARY_FOR_CXX_ATOMIC)
+		message(FATAL_ERROR "Host compiler does not support std::atomic")
+	endif()
+endif()

--- a/cmake/atomic.cmake
+++ b/cmake/atomic.cmake
@@ -1,6 +1,6 @@
 # check for atomic library, which is needed on some architectures
 include(CheckCXXSourceCompiles)
-function(check_working_cxx_atomic varname)
+function(check_cxx_atomic_compiles varname)
 	check_cxx_source_compiles("
 	#include <atomic>
 	std::atomic<bool> x;
@@ -8,6 +8,29 @@ function(check_working_cxx_atomic varname)
 		bool y = false;
 		return !x.compare_exchange_strong(y, true);
 	}" ${varname})
+endfunction()
+function(check_working_cxx_atomic varname)
+	check_cxx_atomic_compiles(${varname}_NOFLAG)
+	if(${varname}_NOFLAG)
+		set(${varname} TRUE PARENT_SCOPE)
+		return()
+	endif()
+	set(old_CMAKE_REQUIRED_FLAGS "${CMAKE_REQUIRED_FLAGS}")
+	list(APPEND CMAKE_REQUIRED_FLAGS "-std=c++11")
+	check_cxx_atomic_compiles(${varname}_STD11)
+	set(CMAKE_REQUIRED_FLAGS  "${old_CMAKE_REQUIRED_FLAGS}")
+	if(${varname}_STD11)
+		set(${varname} TRUE PARENT_SCOPE)
+		return()
+	endif()
+	list(APPEND CMAKE_REQUIRED_FLAGS "-std=c++0x")
+	check_cxx_atomic_compiles(${varname}_STD0X)
+	set(CMAKE_REQUIRED_FLAGS  "${old_CMAKE_REQUIRED_FLAGS}")
+	if(${varname}_STD0X)
+		set(${varname} TRUE PARENT_SCOPE)
+		return()
+	endif()
+	set(${varname} FALSE PARENT_SCOPE)
 endfunction()
 check_working_cxx_atomic(HAVE_CXX_ATOMIC)
 if(NOT HAVE_CXX_ATOMIC)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -134,6 +134,10 @@ set_target_properties(foonathan_memory PROPERTIES
                                        OUTPUT_NAME "foonathan_memory-${FOONATHAN_MEMORY_VERSION}"
                                        POSITION_INDEPENDENT_CODE ON)
 
+if(NEED_LIBRARY_FOR_CXX_ATOMIC)
+	target_link_libraries(foonathan_memory PRIVATE -latomic)
+endif()
+
 install(TARGETS foonathan_memory EXPORT foonathan_memoryTargets
         RUNTIME       DESTINATION ${FOONATHAN_MEMORY_RUNTIME_INSTALL_DIR}
         LIBRARY       DESTINATION ${FOONATHAN_MEMORY_LIBRARY_INSTALL_DIR}


### PR DESCRIPTION
Some architectures such as RISC-V have only limited support for atomic
operations and need the GCC atomic helper library for
compare_exchange_strong() to work.

This PR adds a config-time test to check if libatomic is required and
links against it if yes.