### PR TITLE
Fixed what appears to be a typo in allocate_array_unique.

### DIFF
--- a/include/foonathan/memory/smart_ptr.hpp
+++ b/include/foonathan/memory/smart_ptr.hpp
@@ -79,7 +79,7 @@ namespace foonathan
                 auto memory = alloc.allocate_array(size, sizeof(T), alignof(T));
                 // raw_ptr deallocates memory in case of constructor exception
                 raw_ptr result(static_cast<T*>(memory), {alloc, size});
-                construct(std::integral_constant<bool, noexcept_OP(T())>{}, result.get(),
+                construct(std::integral_constant<bool, noexcept(T())>{}, result.get(),
                           result.get() + size);
                 // pass ownership to return value using a deleter that calls destructor
                 return {result.release(), {alloc, size}};


### PR DESCRIPTION
The text "noexcept_OP" was present, leading to a compile error. I'm not
sure what that was about, but changing it to simply "noexcept" fixes it,
and I can construct unique_ptr<T[]> successfully, now.