### PR TITLE
Fixed memory_pool::min_block_size calculation

### DIFF
--- a/include/foonathan/memory/detail/free_list.hpp
+++ b/include/foonathan/memory/detail/free_list.hpp
@@ -10,6 +10,7 @@
 
 #include "align.hpp"
 #include "utility.hpp"
+#include "debug_helpers.hpp"
 #include "../config.hpp"
 
 namespace foonathan
@@ -28,6 +29,11 @@ namespace foonathan
                 static constexpr auto min_element_size = sizeof(char*);
                 // alignment
                 static constexpr auto min_element_alignment = alignof(char*);
+
+                static constexpr std::size_t actual_node_size(std::size_t node_size) noexcept
+                {
+                    return adjusted_node_size(node_size) + 2 * fence_size();
+                }
 
                 //=== constructor ===//
                 free_memory_list(std::size_t node_size) noexcept;
@@ -92,7 +98,16 @@ namespace foonathan
                 }
 
             private:
-                std::size_t fence_size() const noexcept;
+
+                static constexpr std::size_t adjusted_node_size(std::size_t requested_size) noexcept
+                {
+                    return requested_size > min_element_size ? requested_size : min_element_size;
+                }
+                static constexpr std::size_t fence_size() noexcept
+                {
+                    return detail::debug_fence_size ? max_alignment : 0u;
+                }
+
                 void        insert_impl(void* mem, std::size_t size) noexcept;
 
                 char*       first_;
@@ -111,6 +126,11 @@ namespace foonathan
                 static constexpr auto min_element_size = sizeof(char*);
                 // alignment
                 static constexpr auto min_element_alignment = alignof(char*);
+
+                static constexpr std::size_t actual_node_size(std::size_t node_size) noexcept
+                {
+                    return adjusted_node_size(node_size) + 2 * fence_size(adjusted_node_size(node_size));
+                }
 
                 //=== constructor ===//
                 ordered_free_memory_list(std::size_t node_size) noexcept;
@@ -186,7 +206,14 @@ namespace foonathan
                 }
 
             private:
-                std::size_t fence_size() const noexcept;
+                static constexpr std::size_t adjusted_node_size(std::size_t requested_size) noexcept
+                {
+                    return requested_size > min_element_size ? requested_size : min_element_size;
+                }
+                static constexpr std::size_t fence_size(std::size_t node_size) noexcept
+                {
+                    return detail::debug_fence_size ? node_size : 0u;
+                }
 
                 // returns previous pointer
                 char* insert_impl(void* mem, std::size_t size) noexcept;

--- a/include/foonathan/memory/detail/small_free_list.hpp
+++ b/include/foonathan/memory/detail/small_free_list.hpp
@@ -9,6 +9,7 @@
 
 #include "../config.hpp"
 #include "utility.hpp"
+#include "debug_helpers.hpp"
 
 namespace foonathan
 {
@@ -46,6 +47,11 @@ namespace foonathan
                 static constexpr std::size_t min_element_size = 1;
                 // alignment
                 static constexpr std::size_t min_element_alignment = 1;
+
+                static constexpr std::size_t actual_node_size(std::size_t node_size) noexcept
+                {
+                    return adjusted_node_size(node_size) + 2 * fence_size(adjusted_node_size(node_size));
+                }
 
                 //=== constructor ===//
                 small_free_memory_list(std::size_t node_size) noexcept;
@@ -127,7 +133,16 @@ namespace foonathan
                 }
 
             private:
-                std::size_t fence_size() const noexcept;
+
+                static constexpr std::size_t adjusted_node_size(std::size_t requested_size) noexcept
+                {
+                    // mainly here for consistency with other free_list implementaions; min_element_size=1 makes it a no-op.
+                    return requested_size;
+                }
+                static constexpr std::size_t fence_size(std::size_t node_size) noexcept
+                {
+                    return detail::debug_fence_size ? node_size : 0u;
+                }
 
                 chunk* find_chunk_impl(std::size_t n = 1) noexcept;
                 chunk* find_chunk_impl(unsigned char* node, chunk_base* first,

--- a/include/foonathan/memory/memory_pool.hpp
+++ b/include/foonathan/memory/memory_pool.hpp
@@ -55,8 +55,9 @@ namespace foonathan
             using allocator_type = make_block_allocator_t<BlockOrRawAllocator>;
             using pool_type      = PoolType;
 
+            // actual minimum node size, including any debug fence additions.
             static constexpr std::size_t min_node_size =
-                FOONATHAN_IMPL_DEFINED(free_list::min_element_size);
+                FOONATHAN_IMPL_DEFINED(free_list::actual_node_size(free_list::min_element_size));
 
             /// \returns The minimum block size required for certain number of \concept{concept_node,node}.
             /// \requires \c node_size must be a valid \concept{concept_node,node size}
@@ -65,9 +66,7 @@ namespace foonathan
                                                         std::size_t number_of_nodes) noexcept
             {
                 return detail::memory_block_stack::implementation_offset()
-                       + number_of_nodes
-                             * (((node_size > min_node_size) ? node_size : min_node_size)
-                                + (detail::debug_fence_size ? 2 * detail::max_alignment : 0));
+                       + number_of_nodes * free_list::actual_node_size(node_size);
             }
 
             /// \effects Creates it by specifying the size each \concept{concept_node,node} will have,


### PR DESCRIPTION
Previously, memory_pool::min_block_size() would not compute true node
size in the same way that the individual free list implementations did.
For instance, ordered_free_memory_list uses 2*node_size as debug fence
memory, which memory_pool was disregarding. This could result in a
failure at runtime, if the block was too small for a full node,
including debug fences.

Now, each free_list impl exposes "actual_node_size(n)", which produces
the true required size, given the requested node size. This function is
the same as what's used in the real internal size computations.

Also hoisted fence_size() into constexpr functions in each free_list
implementation, as well as added an "adjusted_node_size" function, which
is mainly for readability, to avoid having "x > y ? x : y" repeated.

Test added to exercise the bug.

Addresses issue #109 