### PR TITLE
Fixed recursive allocator reference issue due to constructor overload resolution

### DIFF
--- a/include/foonathan/memory/allocator_storage.hpp
+++ b/include/foonathan/memory/allocator_storage.hpp
@@ -744,6 +744,14 @@ namespace foonathan
                 alloc.clone(&storage_);
             }
 
+            /// \effects Creates it from the internal base class for the type-erasure.
+            /// Has the same effect as if the actual stored allocator were passed to the other constructor overloads.
+            /// \note This constructor is used internally to avoid double-nesting.
+            reference_storage(FOONATHAN_IMPL_DEFINED(base_allocator) & alloc) noexcept
+            : reference_storage(static_cast<const base_allocator&>(alloc))
+            {
+            }
+
             /// @{
             /// \effects Copies the \c reference_storage object.
             /// It only copies the pointer to the allocator.


### PR DESCRIPTION
We need a non-const constructor here otherwise the `std::scoped_allocator_adaptor` will have issues when using `any_allocator_reference` creating nested type-erased allocators. This can be specially an issue when the allocator it references was a temporary or has gone out-of-scope.

I haven't tested on other compilers, but this was the case in MSVC at least: without this overload, it would choose

            template <class RawAllocator>
            reference_storage(RawAllocator& alloc) noexcept

instead and keep nesting an allocator reference into another reference.