### PR TITLE
Fixing Main CI workflow

### DIFF
--- a/.github/workflows/main_ci.yml
+++ b/.github/workflows/main_ci.yml
@@ -88,31 +88,6 @@ jobs:
     - name: Create Build Environment
       run: cmake -E make_directory build
 
-    - name: Configure and build
-      uses: lukka/run-cmake@main
-      with:
-       cmakeGenerator: 'Ninja'
-       cmakeListsOrSettingsJson: 'CMakeListsTxtBasic'
-       cmakeListsTxtPath: '${{ github.workspace }}/CMakeLists.txt'
-       useVcpkgToolchainFile: true
-       buildDirectory: 'build/'
-    - name: Test
-      working-directory: build/
-      run: ctest -C Debug --output-on-failure
-
-  windows:
-    strategy:
-      fail-fast: false
-      matrix:
-        build_type: [Debug, Release]
-
-    runs-on: windows-latest
-
-    steps:
-    - uses: actions/checkout@v2
-    - name: Create Build Environment
-      run: cmake -E make_directory build
-
     - name: Configure
       shell: bash
       working-directory: build/


### PR DESCRIPTION
Main CI is failing since [this one](https://github.com/foonathan/memory/actions/runs/796721444).

It seems 04f97a2b5b218598b80bb1ef21b784d6a72e16c5 is the responsible, as a duplicate `windows` job was added. This PR removes the old windows job.