### PR TITLE
Add vcpkg installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,18 @@ To use an installed library:
 
 See https://memory.foonathan.net/md_doc_installation.html for a detailed guide.
 
+## Building foonathan-memory - Using vcpkg
+
+You can download and install foonathan-memory using the [vcpkg](https://github.com/Microsoft/vcpkg) dependency manager:
+
+    git clone https://github.com/Microsoft/vcpkg.git
+    cd vcpkg
+    ./bootstrap-vcpkg.sh
+    ./vcpkg integrate install
+    ./vcpkg install foonathan-memory
+
+The foonathan-memory port in vcpkg is kept up to date by Microsoft team members and community contributors. If the version is out of date, please [create an issue or pull request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.
+
 ## Documentation
 
 Full documentation can be found at https://memory.foonathan.net/.


### PR DESCRIPTION
foonathan-memory is available as a port in [vcpkg](https://github.com/microsoft/vcpkg), a C++ library manager that simplifies installation for foonathan-memory and other project dependencies. Documenting the install process here will help users get started by providing a single set of commands to build foonathan-memory, ready to be included in their projects.

We also test whether our library ports build in various configurations (dynamic, static) on various platforms (OSX, Linux, Windows: x86, x64) to keep a wide coverage for users.

I'm a maintainer for vcpkg, and [here is what the port script looks like](https://github.com/microsoft/vcpkg/blob/master/ports/foonathan-memory/portfile.cmake). We try to keep the library maintained as close as possible to the original library. :)