### PR TITLE
Address issue #138

### DIFF
--- a/cmake/get_align_of.cpp
+++ b/cmake/get_align_of.cpp
@@ -9,4 +9,8 @@ struct align_of
 template<typename T>
 using get_align_of = align_of<T, alignof(T)>;
 
+// Workaround for environments that have issues passing in type names with spaces
+using LONG_LONG = long long;
+using LONG_DOUBLE = long double;
+
 get_align_of<TEST_TYPE> dummy;

--- a/cmake/get_container_node_sizes.cmake
+++ b/cmake/get_container_node_sizes.cmake
@@ -4,7 +4,9 @@
 # is being processed.
 set(_THIS_MODULE_DIR ${CMAKE_CURRENT_LIST_DIR})
 
-set(_DEBUG_GET_CONTAINER_NODE_SIZES OFF)
+if(NOT DEFINED _DEBUG_GET_CONTAINER_NODE_SIZES)
+    set(_DEBUG_GET_CONTAINER_NODE_SIZES OFF)
+endif()
 
 function(_gcns_debug_message)
     if(_DEBUG_GET_CONTAINER_NODE_SIZES)
@@ -50,7 +52,7 @@ function(unique_aligned_types result_types result_alignments)
     set(alignments )
     set(types )
 
-    set(all_types char bool short int long "long long" float double "long double")
+    set(all_types char bool short int long LONG_LONG float double LONG_DOUBLE)
     foreach(type IN LISTS all_types )
 	get_alignof_type("${type}" alignment)
 	_gcns_debug_message("Alignment of '${type}' is '${alignment}'")

--- a/cmake/get_node_size.cpp
+++ b/cmake/get_node_size.cpp
@@ -53,7 +53,7 @@ template<typename T, typename State = empty_state, bool SubtractTSize = true, ty
 struct debug_allocator :
     public node_size_of<alignof(InitialType),
 			sizeof(T) - (SubtractTSize ? sizeof(InitialType) : 0),
-			!is_same<InitialType,T>::value>,
+			!is_same<InitialType,T>::value && (sizeof(InitialType) != sizeof(T))>,
     private State
 {
     template<typename U>
@@ -200,6 +200,10 @@ int test_container()
     return 0;
 }
 #endif // SHARED_PTR_STATEFUL_CONTAINER
+
+// Workaround for environments that have issues passing in type names with spaces
+using LONG_LONG = long long;
+using LONG_DOUBLE = long double;
 
 #ifdef TEST_TYPES
 template<typename... Types>


### PR DESCRIPTION
Workaround command line quoting issue for types with spaces, and also address std lib implementations that wrap value types in some containers in a conatiner type of the same size.