### PR TITLE
Increase cmake_minimum_required to 3.14

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@
 
 # root CMakeLists.txt, specifies option and interface library
 
-cmake_minimum_required(VERSION 3.11)
+cmake_minimum_required(VERSION 3.14)
 project(FOONATHAN_MEMORY)
 
 set(FOONATHAN_MEMORY_VERSION_MAJOR 0 CACHE STRING "major version of memory" FORCE)


### PR DESCRIPTION
`FetchContent_MakeAvailable` CMake command is being used and it was introduced in CMake version 3.14. This PR increases the cmake_minimum_required.