### PR TITLE
Add support for QNX 7.1 build

### DIFF
--- a/build_qnx/Makefile
+++ b/build_qnx/Makefile
@@ -1,0 +1,7 @@
+ifndef QRECURSE
+QRECURSE=recurse.mk
+ifdef QCONFIG
+QRDIR=$(dir $(QCONFIG))
+endif
+endif
+include $(QRDIR)$(QRECURSE)

--- a/build_qnx/common.mk
+++ b/build_qnx/common.mk
@@ -1,0 +1,80 @@
+ifndef QCONFIG
+QCONFIG=qconfig.mk
+endif
+include $(QCONFIG)
+
+NAME=memory
+
+#$(INSTALL_ROOT_$(OS)) is pointing to $QNX_TARGET
+#by default, unless it was manually re-routed to
+#a staging area by setting both INSTALL_ROOT_nto
+#and USE_INSTALL_ROOT
+MEMORY_INSTALL_ROOT ?= $(INSTALL_ROOT_$(OS))
+
+MEMORY_VERSION = 0.7-3
+
+#choose Release or Debug
+CMAKE_BUILD_TYPE ?= Release
+
+#set the following to FALSE if generating .pinfo files is causing problems
+GENERATE_PINFO_FILES ?= TRUE
+
+#override 'all' target to bypass the default QNX build system
+ALL_DEPENDENCIES = memory_all
+.PHONY: memory_all install check clean
+
+CFLAGS += $(FLAGS)
+LDFLAGS += -Wl,--build-id=md5
+
+define PINFO
+endef
+PINFO_STATE=Experimental
+USEFILE=
+
+include $(MKFILES_ROOT)/qtargets.mk
+
+CMAKE_ARGS = -DCMAKE_TOOLCHAIN_FILE=$(PROJECT_ROOT)/qnx.nto.toolchain.cmake \
+             -DCMAKE_INSTALL_LIBDIR=$(MEMORY_INSTALL_ROOT)/$(CPUVARDIR)/usr/lib \
+             -DCMAKE_INSTALL_PREFIX=$(MEMORY_INSTALL_ROOT)/$(CPUVARDIR)/usr \
+             -DCMAKE_BUILD_TYPE=$(CMAKE_BUILD_TYPE) \
+             -DEXTRA_CMAKE_C_FLAGS="$(CFLAGS)" \
+             -DEXTRA_CMAKE_CXX_FLAGS="$(CFLAGS)" \
+             -DEXTRA_CMAKE_ASM_FLAGS="$(FLAGS)" \
+             -DEXTRA_CMAKE_LINKER_FLAGS="$(LDFLAGS)" \
+             -DBUILD_SHARED_LIBS=1 \
+             -DDOCTEST_USE_STD_HEADERS=ON
+
+MAKE_ARGS ?= -j $(firstword $(JLEVEL) 1)
+
+ifndef NO_TARGET_OVERRIDE
+memory_all:
+	@mkdir -p build
+	@cd build && cmake $(CMAKE_ARGS) $(PROJECT_ROOT)/../
+	@cd build && make VERBOSE=1 all $(MAKE_ARGS)
+
+install check: memory_all
+	@echo Installing...
+	@cd build && make VERBOSE=1 install all $(MAKE_ARGS)
+	@echo Done.
+
+clean iclean spotless:
+	rm -fr build
+
+uninstall:
+endif
+
+#everything down below deals with the generation of the PINFO
+#information for shared objects that is used by the QNX build
+#infrastructure to embed metadata in the .so files, for example
+#data and time, version number, description, etc. Metadata can
+#be retrieved on the target by typing 'use -i <path to openblas .so file>'.
+#this is optional: setting GENERATE_PINFO_FILES to FALSE will disable
+#the insertion of metadata in .so files.
+ifeq ($(GENERATE_PINFO_FILES), TRUE)
+#the following rules are called by the cmake generated makefiles,
+#in order to generate the .pinfo files for the shared libraries
+%.so$(MEMORY_VERSION):
+	$(ADD_PINFO)
+	$(ADD_USAGE)
+
+endif

--- a/build_qnx/nto/Makefile
+++ b/build_qnx/nto/Makefile
@@ -1,0 +1,8 @@
+LIST=CPU
+ifndef QRECURSE
+QRECURSE=recurse.mk
+ifdef QCONFIG
+QRDIR=$(dir $(QCONFIG))
+endif
+endif
+include $(QRDIR)$(QRECURSE)

--- a/build_qnx/nto/aarch64/Makefile
+++ b/build_qnx/nto/aarch64/Makefile
@@ -1,0 +1,8 @@
+LIST=VARIANT
+ifndef QRECURSE
+QRECURSE=recurse.mk
+ifdef QCONFIG
+QRDIR=$(dir $(QCONFIG))
+endif
+endif
+include $(QRDIR)$(QRECURSE)

--- a/build_qnx/nto/aarch64/le/Makefile
+++ b/build_qnx/nto/aarch64/le/Makefile
@@ -1,0 +1,5 @@
+include ../../../common.mk
+
+CMAKE_ARGS += -DCMAKE_SYSTEM_PROCESSOR=aarch64
+FLAGS      += $(VFLAG_le) $(CCVFLAG_le)
+LDFLAGS    += $(VFLAG_le) $(LDVFLAG_le)

--- a/build_qnx/nto/x86_64/Makefile
+++ b/build_qnx/nto/x86_64/Makefile
@@ -1,0 +1,8 @@
+LIST=VARIANT
+ifndef QRECURSE
+QRECURSE=recurse.mk
+ifdef QCONFIG
+QRDIR=$(dir $(QCONFIG))
+endif
+endif
+include $(QRDIR)$(QRECURSE)

--- a/build_qnx/nto/x86_64/so/Makefile
+++ b/build_qnx/nto/x86_64/so/Makefile
@@ -1,0 +1,5 @@
+include ../../../common.mk
+
+CMAKE_ARGS += -DCMAKE_SYSTEM_PROCESSOR=x86_64
+FLAGS      += $(VFLAG) $(CCVFLAG)
+LDFLAGS    += $(VFLAG) $(LDVFLAG)

--- a/build_qnx/qnx.nto.toolchain.cmake
+++ b/build_qnx/qnx.nto.toolchain.cmake
@@ -1,0 +1,34 @@
+if("$ENV{QNX_HOST}" STREQUAL "")
+    message(FATAL_ERROR "QNX_HOST environment variable not found. Please set the variable to your host's build tools")
+endif()
+if("$ENV{QNX_TARGET}" STREQUAL "")
+    message(FATAL_ERROR "QNX_TARGET environment variable not found. Please set the variable to the qnx target location")
+endif()
+
+if(CMAKE_HOST_WIN32)
+    set(HOST_EXECUTABLE_SUFFIX ".exe")
+    #convert windows paths to cmake paths
+    file(TO_CMAKE_PATH "$ENV{QNX_HOST}" QNX_HOST)
+    file(TO_CMAKE_PATH "$ENV{QNX_TARGET}" QNX_TARGET)
+else()
+    set(QNX_HOST "$ENV{QNX_HOST}")
+    set(QNX_TARGET "$ENV{QNX_TARGET}")
+endif()
+
+message(STATUS "using QNX_HOST ${QNX_HOST}")
+message(STATUS "using QNX_TARGET ${QNX_TARGET}")
+
+set(QNX TRUE)
+set(CMAKE_SYSTEM_NAME QNX)
+set(CMAKE_C_COMPILER ${QNX_HOST}/usr/bin/qcc)
+set(CMAKE_CXX_COMPILER ${QNX_HOST}/usr/bin/qcc)
+set(CMAKE_ASM_COMPILER ${QNX_HOST}/usr/bin/qcc)
+set(CMAKE_AR "${QNX_HOST}/usr/bin/nto${CMAKE_SYSTEM_PROCESSOR}-ar${HOST_EXECUTABLE_SUFFIX}" CACHE PATH "archiver")
+set(CMAKE_RANLIB "${QNX_HOST}/usr/bin/nto${CMAKE_SYSTEM_PROCESSOR}-ranlib${HOST_EXECUTABLE_SUFFIX}" CACHE PATH "ranlib")
+
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Vgcc_nto${CMAKE_SYSTEM_PROCESSOR} ${EXTRA_CMAKE_C_FLAGS}" CACHE STRING "c_flags")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Vgcc_nto${CMAKE_SYSTEM_PROCESSOR} -std=gnu++11 ${EXTRA_CMAKE_CXX_FLAGS}" CACHE STRING "cxx_flags")
+set(CMAKE_ASM_FLAGS "${CMAKE_ASM_FLAGS} -Vgcc_nto${CMAKE_SYSTEM_PROCESSOR} ${EXTRA_CMAKE_ASM_FLAGS}" CACHE STRING "asm_flags")
+
+set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${EXTRA_CMAKE_LINKER_FLAGS}" CACHE STRING "exe_linker_flags")
+set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} ${EXTRA_CMAKE_LINKER_FLAGS}" CACHE STRING "so_linker_flags")

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -44,3 +44,6 @@ target_include_directories(foonathan_memory_test PRIVATE
 
 add_test(NAME test COMMAND foonathan_memory_test)
 
+if(QNX)
+    install(TARGETS foonathan_memory_test DESTINATION bin/)
+endif()


### PR DESCRIPTION
Add support for QNX 7.1 build.

Build instruction:
```bash
source <path-to-qnxsdp-env.sh>/qnxsdp-env.sh
git clone https://github.com/chachoi/memory.git && cd memory/build_qnx
make -j 4 install
```
[Test wiki](https://gitlab.com/qnx/libs/memory/-/wikis/Test-memory)

foonathan_memory_test runs successfully on a QNX 7.1 target:
```console
# ./foonathan_memory_test 
[doctest] doctest version is "2.4.9"
[doctest] run with "--help" for options
===============================================================================
[doctest] test cases:     40 |     40 passed | 0 failed | 0 skipped
[doctest] assertions: 164923 | 164923 passed | 0 failed |
[doctest] Status: SUCCESS!
```
