### PR TITLE
Fix virtual_block_allocator::deallocate_block

### DIFF
--- a/include/foonathan/memory/virtual_memory.hpp
+++ b/include/foonathan/memory/virtual_memory.hpp
@@ -137,6 +137,8 @@ namespace foonathan
             explicit virtual_block_allocator(std::size_t block_size, std::size_t no_blocks);
 
             /// \effects Releases the reserved virtual memory.
+            /// \requires All previously \ref allocate_block() committed blocks must be decommitted via
+            /// \ref deallocate_block(), otherwise the blocks that have not been deallocated are leaked.
             ~virtual_block_allocator() noexcept;
 
             /// @{

--- a/src/virtual_memory.cpp
+++ b/src/virtual_memory.cpp
@@ -230,7 +230,7 @@ void virtual_block_allocator::deallocate_block(memory_block block) noexcept
                                 { return static_cast<char*>(block.memory) == cur_ - block_size_; },
                                 info(), block.memory);
     cur_ -= block_size_;
-    virtual_memory_decommit(cur_, block_size_);
+    virtual_memory_decommit(cur_, block_size_ / virtual_memory_page_size);
 }
 
 allocator_info virtual_block_allocator::info() noexcept

--- a/test/default_allocator.cpp
+++ b/test/default_allocator.cpp
@@ -9,6 +9,7 @@
 #include <vector>
 
 #include "detail/align.hpp"
+#include "memory_arena.hpp"
 
 using namespace foonathan::memory;
 
@@ -71,4 +72,16 @@ TEST_CASE("virtual_memory_allocator")
 {
     virtual_memory_allocator alloc;
     check_default_allocator(alloc, get_virtual_memory_page_size());
+}
+
+TEST_CASE("virtual_block_allocator")
+{
+    auto const              page_size = get_virtual_memory_page_size();
+    constexpr std::size_t   no_blocks{8u};
+
+    virtual_block_allocator alloc{page_size, no_blocks};
+    auto                    block = alloc.allocate_block();
+    REQUIRE(block.memory != nullptr);
+    REQUIRE(block.size == page_size);
+    alloc.deallocate_block(block);
 }


### PR DESCRIPTION
* `deallocate_block()` now calls `virtual_memory_decommit()` with the number of pages to decommit rather than the block size
* extended virtual_block_allocator dtor requirements