### PR TITLE
Fix error: unused variable 'result'

### DIFF
--- a/include/foonathan/memory/detail/assert.hpp
+++ b/include/foonathan/memory/detail/assert.hpp
@@ -44,7 +44,7 @@ namespace foonathan
 
 #elif !defined(FOONATHAN_MEMORY_ASSERT)
 #define FOONATHAN_MEMORY_ASSERT(Expr)
-#define FOONATHAN_MEMORY_ASSERT_MSG(Expr, Msg)
+#define FOONATHAN_MEMORY_ASSERT_MSG(Expr, Msg) (void)(Expr) //unused var
 #define FOONATHAN_MEMORY_UNREACHABLE(Msg) std::abort()
 #define FOONATHAN_MEMORY_WARNING(Msg)
 #endif


### PR DESCRIPTION
Hi,

When I build this project (with gcc 14) for this code:

https://github.com/foonathan/memory/blob/016c9fbd61b57ed2058551dcf225c15a0e716cce/src/virtual_memory.cpp#L48-L52

I had this error:

>src/virtual_memory.cpp: In function 'void foonathan::memory::virtual_memory_release(void*, std::size_t)':
src/virtual_memory.cpp:50:10: error: unused variable 'result' [-Werror=unused-variable]
   50 |     auto result = VirtualFree(pages, 0u, MEM_RELEASE);
      |          ^~~~~~

it happens when `FOONATHAN_MEMORY_DEBUG_ASSERT` is not defined and then `FOONATHAN_MEMORY_ASSERT_MSG` is an empty macro and then `result` is not used.

This PR is to fix the compiling error.