### PR TITLE
（MinGW-GCC8.1）Fix unused variables caused by FOONATHAN_MEMORY_ASSERT_MSG is not d…

### DIFF
--- a/src/virtual_memory.cpp
+++ b/src/virtual_memory.cpp
@@ -49,6 +49,7 @@ void foonathan::memory::virtual_memory_release(void* pages, std::size_t) noexcep
 {
     auto result = VirtualFree(pages, 0u, MEM_RELEASE);
     FOONATHAN_MEMORY_ASSERT_MSG(result, "cannot release pages");
+    (void)result;
 }
 
 void* foonathan::memory::virtual_memory_commit(void* memory, std::size_t no_pages) noexcept
@@ -70,6 +71,7 @@ void foonathan::memory::virtual_memory_decommit(void* memory, std::size_t no_pag
 {
     auto result = VirtualFree(memory, no_pages * virtual_memory_page_size, MEM_DECOMMIT);
     FOONATHAN_MEMORY_ASSERT_MSG(result, "cannot decommit memory");
+    (void)result;
 }
 #elif defined(__unix__) || defined(__APPLE__) || defined(__VXWORKS__)                              \
     || defined(__QNXNTO__) // POSIX systems


### PR DESCRIPTION
When I compile the code using mingw64 (GCC 8.1), the following error occurs:
```shell
.../src/virtual_memory.cpp
.../src/virtual_memory.cpp: In function 'void foonathan::memory::virtual_memory_release(void*, std::size_t)':
.../src/v0.7-3-8e7bcb82b7.clean/src/virtual_memory.cpp:50:10: error: unused variable 'result' [-Werror=unused-variable]
     auto result = VirtualFree(pages, 0u, MEM_RELEASE);
          ^~~~~~
.../src/v0.7-3-8e7bcb82b7.clean/src/virtual_memory.cpp: In function 'void foonathan::memory::virtual_memory_decommit(void*, std::size_t)':
.../src/virtual_memory.cpp:71:10: error: unused variable 'result' [-Werror=unused-variable]
     auto result = VirtualFree(memory, no_pages * virtual_memory_page_size, MEM_DECOMMIT);
          ^~~~~~
cc1plus.exe: all warnings being treated as errors
```

like [issues-183](https://github.com/foonathan/memory/issues/183) and [pull-184](https://github.com/foonathan/memory/pull/184) as mentioned, however, he has only repaired one problem. There are two of the same problems, and here is another.