### PR TITLE
Size suffixes cannot have a space.

### DIFF
--- a/include/foonathan/memory/memory_arena.hpp
+++ b/include/foonathan/memory/memory_arena.hpp
@@ -656,32 +656,32 @@ namespace foonathan
             /// \returns The number of bytes `value` is in the given unit.
             /// \ingroup core
             /// @{
-            constexpr std::size_t operator"" _KiB(unsigned long long value) noexcept
+            constexpr std::size_t operator""_KiB(unsigned long long value) noexcept
             {
                 return std::size_t(value * 1024);
             }
 
-            constexpr std::size_t operator"" _KB(unsigned long long value) noexcept
+            constexpr std::size_t operator""_KB(unsigned long long value) noexcept
             {
                 return std::size_t(value * 1000);
             }
 
-            constexpr std::size_t operator"" _MiB(unsigned long long value) noexcept
+            constexpr std::size_t operator""_MiB(unsigned long long value) noexcept
             {
                 return std::size_t(value * 1024 * 1024);
             }
 
-            constexpr std::size_t operator"" _MB(unsigned long long value) noexcept
+            constexpr std::size_t operator""_MB(unsigned long long value) noexcept
             {
                 return std::size_t(value * 1000 * 1000);
             }
 
-            constexpr std::size_t operator"" _GiB(unsigned long long value) noexcept
+            constexpr std::size_t operator""_GiB(unsigned long long value) noexcept
             {
                 return std::size_t(value * 1024 * 1024 * 1024);
             }
 
-            constexpr std::size_t operator"" _GB(unsigned long long value) noexcept
+            constexpr std::size_t operator""_GB(unsigned long long value) noexcept
             {
                 return std::size_t(value * 1000 * 1000 * 1000);
             }


### PR DESCRIPTION
This is a warning since LLVM 20.1.0. From the [release notes](https://releases.llvm.org/20.1.0/tools/clang/docs/ReleaseNotes.html):

> The warning `-Wdeprecated-literal-operator` is now on by default, as this is something that WG21 has shown interest in removing from the language. The result is that anyone who is compiling with `-Werror` should see this diagnostic. To fix this diagnostic, simply removing the space character from between the operator"" and the user defined literal name will make the source no longer deprecated. This is consistent with CWG2521 <https://cplusplus.github.io/CWG/issues/2521.html>_.
> 
> ```cpp
> // Now diagnoses by default.
> unsigned operator"" _udl_name(unsigned long long);
> // Fixed version:
> unsigned operator""_udl_name(unsigned long long);
> ```