### PR TITLE
Add force_unlock() to allocator_storage.

### DIFF
--- a/include/foonathan/memory/allocator_storage.hpp
+++ b/include/foonathan/memory/allocator_storage.hpp
@@ -313,6 +313,20 @@ namespace foonathan
             {
                 return StoragePolicy::is_composable();
             }
+
+            /// @{
+            /// \effects Explicitly unlocks the \c Mutex.
+            /// \returns the result of force_unlock() on \c Mutex.
+            /// \note Only available if \c Mutex supports force_unlock().
+            /// \note Calling this function can be dangerous, but may be
+            /// necessary in certain situations (like forcing an allocator
+            /// to be unlocked in an atfork child handler).
+            template <typename M = actual_mutex>
+            auto force_unlock() noexcept -> decltype(std::declval<M&>()->force_unlock())
+            {
+                return static_cast<actual_mutex&>(*this)->force_unlock();
+            }
+            /// @}
         };
 
         /// Tag type that enables type-erasure in \ref reference_storage.

--- a/include/foonathan/memory/threading.hpp
+++ b/include/foonathan/memory/threading.hpp
@@ -33,6 +33,7 @@ namespace foonathan
             }
 
             void unlock() noexcept {}
+            void force_unlock() noexcept {}
         };
 
         /// Specifies whether or not a \concept{concept_rawallocator,RawAllocator} is thread safe as-is.
@@ -99,6 +100,7 @@ namespace foonathan
 
                 void lock() const noexcept {}
                 void unlock() const noexcept {}
+                void force_unlock() const noexcept {}
 
                 mutex_storage const * operator->() const noexcept
                 {

--- a/include/foonathan/memory/threading.hpp
+++ b/include/foonathan/memory/threading.hpp
@@ -79,6 +79,11 @@ namespace foonathan
                     mutex_.unlock();
                 }
 
+                Mutex * operator->() const noexcept
+                {
+                    return std::addressof(mutex_);
+                }
+
             protected:
                 ~mutex_storage() noexcept = default;
 
@@ -94,6 +99,11 @@ namespace foonathan
 
                 void lock() const noexcept {}
                 void unlock() const noexcept {}
+
+                mutex_storage const * operator->() const noexcept
+                {
+                    return this;
+                }
 
             protected:
                 ~mutex_storage() noexcept = default;


### PR DESCRIPTION
This feature is almost never needed. However, when it is needed, it is badly needed.

Consider the case where a program forks. The allowable operations in the child (before calling exec) are very limited. However, we might want to use a special purpose allocator. But, if that allocator can be used my multiple threads, then it is possible that one of those threads is holding the lock when fork is called. This means that the child can't acquire the lock because the thread holding it will never get to run and release the lock within the child process.

In this case, the child must be able to unlock the allocator.

This is, admittedly, a very exceptional use case. However, it has been added in such a way that it will only appear in the API if the provided Mutex type supports `force_unlock`, which is unlikely for most use cases.

The only other way of accomplishing this task is using nasty techniques to subvert the visibility access rules of the language since the mutex is one of multiple a private base classes.

Another small change to support this feature was to add a member access through pointer operator to the mutex storage classes.