### PR TITLE
Fix max_alignment bug in segregator.

### DIFF
--- a/include/foonathan/memory/segregator.hpp
+++ b/include/foonathan/memory/segregator.hpp
@@ -201,7 +201,7 @@ namespace foonathan
                 return fallback_traits::max_array_size(get_fallback_allocator());
             }
 
-            std::size_t max_alignemnt() const
+            std::size_t max_alignment() const
             {
                 return fallback_traits::max_alignment(get_fallback_allocator());
             }

--- a/test/segregator.cpp
+++ b/test/segregator.cpp
@@ -170,3 +170,19 @@ TEST_CASE("segregator")
     REQUIRE(get_fallback_allocator(s).no_allocated() == 1u);
     s.deallocate_node(ptr, 17, 1);
 }
+
+TEST_CASE("binary_segregator max_alignment")
+{
+    struct allocator : test_allocator
+    {
+        std::size_t max_alignment() const noexcept
+        {
+            return std::size_t(4 * 1024);
+        }
+    };
+    using segregatable = threshold_segregatable<allocator>;
+    using segregator   = binary_segregator<segregatable, allocator>;
+
+    segregator s(threshold(8u, allocator{}));
+    REQUIRE(allocator_traits<segregator>::max_alignment(s) == 4 * 1024u);
+}


### PR DESCRIPTION
The bug is a typo of max_alignment.

This caused the SFINAE used in the allocator_traits to use the default max alignment because max_alignment wasn't defined.

This meant that you could never get the right max alignment out of a sergregator composition.