### PR TITLE
CMake improvements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,7 +30,7 @@ if(UNIX OR VXWORKS)
     set(FOONATHAN_MEMORY_ARCHIVE_INSTALL_DIR "${CMAKE_INSTALL_LIBDIR}")
     set(FOONATHAN_MEMORY_FRAMEWORK_INSTALL_DIR "${CMAKE_INSTALL_LIBDIR}")
 
-    set(FOONATHAN_MEMORY_CMAKE_CONFIG_INSTALL_DIR "${CMAKE_INSTALL_LIBDIR}/foonathan_memory/cmake")
+    set(FOONATHAN_MEMORY_CMAKE_CONFIG_INSTALL_DIR "${CMAKE_INSTALL_LIBDIR}/cmake/foonathan_memory")
     set(FOONATHAN_MEMORY_ADDITIONAL_FILES_INSTALL_DIR "${CMAKE_INSTALL_DATADIR}/foonathan_memory")
 elseif(WIN32)
     set(FOONATHAN_MEMORY_INC_INSTALL_DIR "include")
@@ -50,6 +50,8 @@ endif()
 include(cmake/configuration.cmake)
 include(cmake/atomic.cmake)
 include(cmake/get_container_node_sizes.cmake)
+
+option(FOONATHAN_MEMORY_USE_SYSTEM_DOCTEST "Use the system doctest library" OFF)
 
 # subdirectories
 add_subdirectory(src)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -107,7 +107,8 @@ elseif(MSVC)
 endif()
 
 set_target_properties(foonathan_memory PROPERTIES
-                                       OUTPUT_NAME "foonathan_memory-$CACHE{FOONATHAN_MEMORY_VERSION}"
+                                       VERSION ${FOONATHAN_MEMORY_VERSION}
+                                       SOVERSION ${FOONATHAN_MEMORY_VERSION_MAJOR}
                                        POSITION_INDEPENDENT_CODE ON)
 
 if(NEED_LIBRARY_FOR_CXX_ATOMIC)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -8,11 +8,15 @@ target_link_libraries(foonathan_memory_profiling foonathan_memory)
 target_include_directories(foonathan_memory_profiling PRIVATE
                             ${FOONATHAN_MEMORY_SOURCE_DIR}/include/foonathan/memory)
 
-# Fetch doctest.
-message(STATUS "Fetching doctest")
-include(FetchContent)
-FetchContent_Declare(doctest URL https://github.com/doctest/doctest/archive/refs/tags/v2.4.12.zip)
-FetchContent_MakeAvailable(doctest)
+if(FOONATHAN_MEMORY_USE_SYSTEM_DOCTEST)
+    find_package(doctest REQUIRED)
+else()
+    # Fetch doctest.
+    message(STATUS "Fetching doctest")
+    include(FetchContent)
+    FetchContent_Declare(doctest URL https://github.com/doctest/doctest/archive/refs/tags/v2.4.12.zip)
+    FetchContent_MakeAvailable(doctest)
+endif()
 
 set(tests
     test_allocator.hpp


### PR DESCRIPTION
Fix install location of CMake config files
Add FOONATHAN_MEMORY_USE_SYSTEM_DOCTEST option to use system doctest package
Add soversion to shared library