### PR TITLE
Fix assert on constexpr

### DIFF
--- a/include/foonathan/memory/detail/align.hpp
+++ b/include/foonathan/memory/detail/align.hpp
@@ -24,8 +24,9 @@ namespace foonathan
             constexpr std::size_t round_up_to_multiple_of_alignment(std::size_t size,
                                                                     std::size_t alignment) noexcept
             {
-                FOONATHAN_MEMORY_ASSERT(is_valid_alignment(alignment));
-                return (size + alignment - 1) & ~(alignment - 1);
+                return FOONATHAN_MEMORY_ASSERT_RETURN(
+                    is_valid_alignment(alignment),
+                    (size + alignment - 1) & ~(alignment - 1));
             }
 
             // returns the offset needed to align ptr for given alignment

--- a/include/foonathan/memory/detail/assert.hpp
+++ b/include/foonathan/memory/detail/assert.hpp
@@ -40,7 +40,7 @@ namespace foonathan
 #define FOONATHAN_MEMORY_ASSERT_RETURN(Expr, Ret)                                                  \
     ((Expr) ? (Ret)                                                                                \
             : (detail::handle_failed_assert("Assertion \"" #Expr "\" failed", __FILE__,            \
-                                            __LINE__, __func__),                                   \
+                                            __LINE__, "some constexpr"),                           \
                (Ret)))
 
 #define FOONATHAN_MEMORY_UNREACHABLE(Msg)                                                          \

--- a/include/foonathan/memory/detail/assert.hpp
+++ b/include/foonathan/memory/detail/assert.hpp
@@ -37,6 +37,12 @@ namespace foonathan
                                                        __FILE__, __LINE__, __func__),              \
                           true))
 
+#define FOONATHAN_MEMORY_ASSERT_RETURN(Expr, Ret)                                                  \
+    ((Expr) ? (Ret)                                                                                \
+            : (detail::handle_failed_assert("Assertion \"" #Expr "\" failed", __FILE__,            \
+                                            __LINE__, __func__),                                   \
+               (Ret)))
+
 #define FOONATHAN_MEMORY_UNREACHABLE(Msg)                                                          \
     detail::handle_failed_assert("Unreachable code reached: " Msg, __FILE__, __LINE__, __func__)
 
@@ -45,6 +51,7 @@ namespace foonathan
 #elif !defined(FOONATHAN_MEMORY_ASSERT)
 #define FOONATHAN_MEMORY_ASSERT(Expr)
 #define FOONATHAN_MEMORY_ASSERT_MSG(Expr, Msg)
+#define FOONATHAN_MEMORY_ASSERT_RETURN(Expr, Ret) (Ret)
 #define FOONATHAN_MEMORY_UNREACHABLE(Msg) std::abort()
 #define FOONATHAN_MEMORY_WARNING(Msg)
 #endif


### PR DESCRIPTION
This fixes a build error when using `-DCMAKE_BUILD_TYPE=Debug` and forcing C++11